### PR TITLE
add hybrid and sequential execution modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "pyodide": "^0.29.1",
         "solid-codemirror": "^2.3.1",
         "solid-js": "^1.9.10",
+        "solid-transition-group": "^0.3.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -2958,6 +2959,18 @@
         "solid-js": "^1.6.12"
       }
     },
+    "node_modules/@solid-primitives/refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/refs/-/refs-1.1.2.tgz",
+      "integrity": "sha512-K7tf2thy7L+YJjdqXspXOg5xvNEOH8tgEWsp0+1mQk3obHBRD6hEjYZk7p7FlJphSZImS35je3UfmWuD7MhDfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solid-primitives/utils": "^6.3.2"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.6.12"
+      }
+    },
     "node_modules/@solid-primitives/resize-observer": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@solid-primitives/resize-observer/-/resize-observer-2.1.3.tgz",
@@ -2993,6 +3006,15 @@
       "dependencies": {
         "@solid-primitives/utils": "^6.3.2"
       },
+      "peerDependencies": {
+        "solid-js": "^1.6.12"
+      }
+    },
+    "node_modules/@solid-primitives/transition-group": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/transition-group/-/transition-group-1.1.2.tgz",
+      "integrity": "sha512-gnHS0OmcdjeoHN9n7Khu8KNrOlRc8a2weETDt2YT6o1zeW/XtUC6Db3Q9pkMU/9cCKdEmN4b0a/41MKAHRhzWA==",
+      "license": "MIT",
       "peerDependencies": {
         "solid-js": "^1.6.12"
       }
@@ -7047,6 +7069,23 @@
       },
       "peerDependencies": {
         "solid-js": "^1.3"
+      }
+    },
+    "node_modules/solid-transition-group": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/solid-transition-group/-/solid-transition-group-0.3.0.tgz",
+      "integrity": "sha512-gzFbtxkEnA8Hgi7UzmEjPPRl4rodoKLs+AGIXA7kJgjOr4j4qFRw39npu+WpdNSDV7aDKr+K0LFcoT9Kbm5PBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solid-primitives/refs": "^1.1.0",
+        "@solid-primitives/transition-group": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.6.12"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pyodide": "^0.29.1",
     "solid-codemirror": "^2.3.1",
     "solid-js": "^1.9.10",
+    "solid-transition-group": "^0.3.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/components/CodeCell.tsx
+++ b/src/components/CodeCell.tsx
@@ -16,27 +16,27 @@ interface CodeCellProps {
 const CodeCell: Component<CodeCellProps> = (props) => {
   // Local running state replaced by store state
   // const [running, setRunning] = createSignal(false);
+  const [hovered, setHovered] = createSignal(false);
 
-  const handleRun = async () => {
-    if (props.cell.isRunning) return;
-    actions.setCellRunning(props.cell.id, true);
-    actions.clearCellOutput(props.cell.id);
-    try {
-      await kernel.run(props.cell.content, (result) => {
-        actions.updateCellOutput(props.cell.id, result);
+  // We rely on the parent (Notebook) or store logic to handle the run
+  // But CodeCell needs to invoke the store action directly now to participate in queue
+  // Actually, handleRun logic was moved to store actions.executeCell, but we need to call runCell wrapper.
+  // The Notebook passes "runCell" logic implicitly? No, we need to import actions or use props.
+  // Ideally CodeCell should just call actions.runCell.
+  
+  const handleRun = () => {
+      actions.runCell(props.cell.id, async (content, id) => {
+        await kernel.run(content, (result) => {
+            actions.updateCellOutput(id, result);
+        });
       });
-    } catch (e) {
-      console.error(e);
-    } finally {
-      actions.setCellRunning(props.cell.id, false);
-    }
   };
 
   const toolbar = (
     <div class="flex lg:hidden items-center gap-1 p-1">
       <button 
         onClick={handleRun}
-        disabled={props.cell.isRunning}
+        disabled={props.cell.isRunning || props.cell.isQueued}
         class={clsx(
           "p-1.5 hover:bg-foreground rounded-sm disabled:opacity-50",
           props.cell.outputs?.error ? "text-primary" : (props.isActive || props.cell.isEditing) ? "text-accent" : "text-accent"
@@ -44,7 +44,9 @@ const CodeCell: Component<CodeCellProps> = (props) => {
         title="Run Cell (Ctrl+Enter)"
       >
         <Show when={!props.cell.isRunning} fallback={<Square size={16} class="animate-pulse text-primary" />}>
-          <Play size={16} />
+          <Show when={props.cell.isQueued} fallback={<Play size={16} />}>
+             <div class="text-[10px] font-bold uppercase tracking-wider text-accent/70">Wait</div>
+          </Show>
         </Show>
       </button>
       <div class="h-4 w-px bg-foreground mx-1" />
@@ -73,12 +75,18 @@ const CodeCell: Component<CodeCellProps> = (props) => {
       type="code"
       onActionClick={handleRun}
       actionRunning={props.cell.isRunning}
+      isQueued={props.cell.isQueued}
       hasError={!!props.cell.outputs?.error}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       <div class="flex flex-col">
-        <div class="flex p-2 pl-1">
+        <div class={clsx("flex relative pl-1.75 z-10", props.cell.outputs && (props.cell.outputs.stdout.length > 0 || props.cell.outputs.stderr.length > 0 || props.cell.outputs.result || props.cell.outputs.error) ? "pt-2 px-2 pb-0" : "p-2")}>
            {/* Line numbers gutter could go here */}
-           <div class="w-10 bg-background border-r border-foreground flex flex-col items-center pt-5.5 text-xs text-foreground select-none font-mono">
+           <div class={clsx(
+             "w-10 bg-background border-r border-foreground flex flex-col items-center pt-5.5 pr-1.5 text-xs select-none font-mono",
+             props.cell.outputs?.executionKernelId === kernel.id ? "text-secondary/50 font-bold" : "text-foreground"
+           )}>
               [{props.index + 1}]:
            </div>
            <div class="flex-1 bg-background relative">
@@ -101,6 +109,62 @@ const CodeCell: Component<CodeCellProps> = (props) => {
              </Show>
            </div>
         </div>
+
+        {/* Timeline Connector */}
+        <Show when={props.cell.outputs && (props.cell.outputs.stdout.length > 0 || props.cell.outputs.stderr.length > 0 || props.cell.outputs.result || props.cell.outputs.error)}>
+           <div class="flex pl-1.5 relative z-0 h-5 my-0.75">
+              <div class="w-10 relative flex items-center justify-center">
+                  <div class={clsx(
+                      "absolute -right-1.25 rounded-full transition-all duration-300",
+                      // Size logic
+                      (props.isActive || props.cell.isEditing) ? "w-2.5 h-2.5" : "w-2.5 h-2.5 group-hover:scale-125",
+                      // Color logic
+                      (() => {
+                          const o = props.cell.outputs;
+                          // Active/Hover/Edit state
+                          if (props.isActive || props.cell.isEditing || hovered()) {
+                              if (!o) return "bg-gray-500";
+                              if (o.executionKernelId && o.executionKernelId !== kernel.id) return "bg-gray-500";
+                              if (o.error) return "bg-red-500";
+                              return "bg-green-500";
+                          }
+                          // Dimmed state - solid color to match border but opaque
+                          // Using a solid gray that approximates the border color
+                          return "bg-zinc-700"; 
+                      })()
+                  )}></div>
+              </div>
+              <div class={clsx(
+                  "flex-1 flex items-center pl-4 gap-3 transition-opacity duration-200",
+                  (props.isActive || props.cell.isEditing || hovered()) ? "opacity-100" : "opacity-0"
+              )}>
+                  <span class="text-[10px] uppercase font-bold tracking-wider text-secondary/40 select-none">
+                      {(() => {
+                          const o = props.cell.outputs;
+                          if (!o || !o.executionTime) return "";
+                          const date = new Date(o.executionTime);
+                          return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+                      })()}
+                  </span>
+                  <Show when={props.cell.outputs?.executionDuration}>
+                      <span class="text-[10px] text-secondary/30 select-none font-mono">
+                          {props.cell.outputs?.executionDuration}ms
+                      </span>
+                  </Show>
+                  <Show when={props.cell.outputs?.error}>
+                      <span class="text-[10px] font-bold text-red-500/70 select-none flex items-center gap-1">
+                          ! Error
+                      </span>
+                  </Show>
+                  <Show when={props.cell.outputs?.executionKernelId && props.cell.outputs.executionKernelId !== kernel.id}>
+                      <span class="text-[10px] italic text-secondary/30 select-none">
+                          (previous session)
+                      </span>
+                  </Show>
+              </div>
+           </div>
+        </Show>
+
         <Show when={props.cell.outputs}>
           <Output outputs={props.cell.outputs} />
         </Show>

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { type Component, createEffect, on } from "solid-js";
+import { type Component } from "solid-js";
 import { createCodeMirror } from "solid-codemirror";
 import { python } from "@codemirror/lang-python";
 import { nord } from "@uiw/codemirror-theme-nord";

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -18,7 +18,7 @@ const Output: Component<OutputProps> = (props) => {
 
   return (
     <Show when={hasContent()}>
-      <div class="flex flex-col gap-1 font-mono text-sm p-2 pl-1 border-foreground max-h-125 overflow-y-auto">
+      <div class="flex flex-col gap-1 font-mono text-sm px-2 pb-2 pt-0 pl-1 border-foreground max-h-125 overflow-y-auto">
         <Show when={props.outputs}>
           <For each={props.outputs?.stdout}>
             {(line) => <div class="text-secondary whitespace-pre-wrap">{line}</div>}
@@ -33,7 +33,7 @@ const Output: Component<OutputProps> = (props) => {
           </Show>
           <Show when={props.outputs?.result}>
             <div class="flex w-full">
-              <div class="w-9.5 bg-background border-r border-foreground flex flex-col items-center pt-5.25 text-sm text-foreground font-extrabold select-none font-mono">Out:</div>
+              <div class="w-10 bg-background border-r border-foreground flex flex-col items-center pt-5.25 text-sm text-foreground font-extrabold select-none font-mono">Out:</div>
               <div class="flex-1 text-secondary/80 whitespace-pre-wrap border-l-4 border-foreground bg-accent/5 pt-5 p-4">
                 {props.outputs?.result}
               </div>

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -63,7 +63,7 @@ const Dropdown: Component<DropdownProps> = (props) => {
   const menuClasses = clsx(
     "shadow-lg bg-background border border-foreground ring-1 ring-black/5 focus:outline-none z-50",
     props.fullWidthMobile ? "max-xs:fixed max-xs:left-0 max-xs:right-0 max-xs:top-16.25 max-xs:mt-0 max-xs:rounded-none max-xs:border-t-0 max-xs:w-auto" : "",
-    props.fullWidthMobile ? "xs:absolute xs:mt-2 xs:w-80 xs:rounded-sm" : "mt-2 w-80 rounded-sm",
+    props.fullWidthMobile ? "xs:absolute xs:mt-2 xs:w-70 sm:w-40 xs:rounded-sm" : "mt-2 w-70 rounded-sm",
     // If NOT using portal, we use relative positioning classes
     !props.usePortal && (props.align === "right" ? "right-0" : "left-0"),
     !props.usePortal && "absolute"
@@ -144,7 +144,7 @@ export const DropdownNested: Component<{ label: JSX.Element; children: JSX.Eleme
       </button>
       <Show when={isOpen()}>
         <div 
-          class="absolute left-full -top-1 w-80 rounded-sm shadow-lg bg-background border border-foreground ring-1 ring-black/5 z-50"
+          class="absolute left-full -top-1 w-70 rounded-sm shadow-lg bg-background border border-foreground ring-1 ring-black/5 z-50"
         >
           <div class="py-1" role="menu" aria-orientation="vertical">
             {props.children}

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,18 @@ body {
   @apply p-2 rounded-[var(--radius-sm)] text-secondary hover:bg-foreground transition-colors cursor-pointer;
 }
 
+/* Sidebar Container Query Logic */
+@container cell-sidebar (max-height: 125px) {
+  .sidebar-inner-auto-center {
+    position: absolute !important;
+    top: 50% !important;
+    transform: translateY(-50%) !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    width: 100% !important;
+  }
+}
+
 /* Milkdown & Prose Overrides */
 .milkdown-editor-wrapper {
   @apply min-h-12.5;
@@ -247,3 +259,8 @@ body {
 .section-scope[data-level="2"] { --primary: var(--header-color-2) !important; --color-primary: var(--header-color-2) !important; }
 .section-scope[data-level="3"] { --primary: var(--header-color-3) !important; --color-primary: var(--header-color-3) !important; }
 .section-scope[data-level="4"] { --primary: var(--header-color-4) !important; --color-primary: var(--header-color-4) !important; }
+
+/* Cell List Transition Group */
+.cell-list-move {
+  transition: transform 0.3s ease-in-out;
+}


### PR DESCRIPTION
Added two new ways to run code cells to PyNote: "hybrid" and "queue_all" (sequential). Now, users can choose whether cells run one after another (queue_all), or use a hybrid mode where a cell waits for the previous one to finish before running. This provides more control over how code executes, especially when cells depend on each other.

Main changes:
- The notebook state now has an `executionMode` field, with options for "hybrid", "queue_all", and "direct".
- The logic for running cells checks the selected mode and queues cells if needed.
- I updated the store and actions so everything works smoothly with these new modes.

This should make working with notebooks more flexible and predictable, especially for longer scripts or when order matters. The default is "hybrid", but modes can be switched as needed. Undo/redo and autosave still work as before.