### PR TITLE
Feature/theme content width

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -435,7 +435,7 @@ const CodeEditor: Component<EditorProps> = (props) => {
       backgroundColor: "transparent !important",
       height: "auto",
       minHeight: "1.5rem",
-      maxHeight: currentTheme.editor.maxCodeHeight,
+      maxHeight: "var(--editor-max-code-height)",
       fontSize: "1rem",
       fontFamily: "var(--font-mono)",
     },

--- a/src/components/Notebook.tsx
+++ b/src/components/Notebook.tsx
@@ -1307,7 +1307,9 @@ const Notebook: Component = () => {
            }
          }}
        >
-         <div class="max-w-202 mx-auto px-7.5 max-xs:pl-6.5 max-xs:pr-2 py-4 flex items-center justify-between" onClick={(e) => e.stopPropagation()}>
+         <div class="px-7.5 max-xs:pl-6.5 max-xs:pr-2 py-4 flex items-center justify-between" 
+              style={{ "max-width": "var(--page-max-width-header)", "margin-left": "var(--page-margin-x-header)", "margin-right": "var(--page-margin-x-header)" }} 
+              onClick={(e) => e.stopPropagation()}>
            <div class="flex items-center gap-2">
              <div class="btn-toolbar bg-primary! text-background! hover:bg-primary/90! flex items-center justify-center font-bold! text-xl! leading-none sm:flex border-primary">PyNote</div>
              <div class="h-8 w-px bg-foreground mx-1 hidden xs:block"></div>
@@ -1920,7 +1922,7 @@ const Notebook: Component = () => {
          </div>
        </div>
 
-       <div class="max-w-208 mx-auto">
+       <div style={{ "max-width": "var(--page-max-width-content)", "margin-left": "var(--page-margin-x-content)", "margin-right": "var(--page-margin-x-content)" }}>
          {/* Cells List */}
          <DragDropProvider onDragStart={onDragStart} onDragEnd={onDragEnd} collisionDetector={closestCorners}>
            <AutoScroller />

--- a/src/components/ThemeDialog.tsx
+++ b/src/components/ThemeDialog.tsx
@@ -22,6 +22,7 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
     sectionScoping: currentTheme.sectionScoping,
     tableOverflow: currentTheme.tableOverflow,
     outputLayout: currentTheme.outputLayout,
+    pageWidth: currentTheme.pageWidth,
     saveToExport: currentTheme.saveToExport,
   };
 
@@ -637,13 +638,6 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
                 placeholder="0.225rem"
                 step={0.0125}
               />
-              <NumberUnitInput
-                label="Header Margin Bottom"
-                value={currentTheme.typography.headerMarginBottom}
-                onChange={(v) => updateTheme({ typography: { ...currentTheme.typography, headerMarginBottom: v } })}
-                placeholder="1.5rem"
-                step={0.125}
-              />
             </div>
 
             {/* Spacing Section */}
@@ -670,6 +664,13 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
                 placeholder="1.25rem"
                 step={0.125}
               />
+              <NumberUnitInput
+                label="Header Margin"
+                value={currentTheme.typography.headerMarginBottom}
+                onChange={(v) => updateTheme({ typography: { ...currentTheme.typography, headerMarginBottom: v } })}
+                placeholder="1.5rem"
+                step={0.125}
+              />
             </div>
 
             {/* Border Radius Section */}
@@ -693,14 +694,21 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
               />
             </div>
 
-            {/* Behavior Section */}
+            {/* Layout Section */}
             <div class="space-y-2">
-              <h3 class="text-xs font-bold text-accent uppercase mb-2">Behavior</h3>
-              <ToggleField
-                label="Section Scoping"
-                value={currentTheme.sectionScoping}
-                onChange={() => updateTheme({ sectionScoping: !currentTheme.sectionScoping })}
-              />
+              <h3 class="text-xs font-bold text-accent uppercase mb-2">Layout</h3>
+              <div class="space-y-1">
+                <label class="text-xs font-semibold text-secondary/80">Page Width</label>
+                <select
+                  value={currentTheme.pageWidth}
+                  onChange={(e) => updateTheme({ pageWidth: e.currentTarget.value as "normal" | "wide" | "full" })}
+                  class="w-full h-9 px-2 text-sm bg-background border border-foreground rounded-sm text-secondary focus:outline-none focus:border-accent transition-colors"
+                >
+                  <option value="normal">Normal (52rem)</option>
+                  <option value="wide">Wide (64rem)</option>
+                  <option value="full">Full Page</option>
+                </select>
+              </div>
               <div class="space-y-1">
                 <label class="text-xs font-semibold text-secondary/80">Table Overflow</label>
                 <select
@@ -712,6 +720,16 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
                   <option value="wrap">Force 100% Width (Wrap)</option>
                 </select>
               </div>
+            </div>
+
+            {/* Markdown Section */}
+            <div class="space-y-2">
+              <h3 class="text-xs font-bold text-accent uppercase mb-2">Markdown</h3>
+              <ToggleField
+                label="Section Scoping"
+                value={currentTheme.sectionScoping}
+                onChange={() => updateTheme({ sectionScoping: !currentTheme.sectionScoping })}
+              />
             </div>
           </div>
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -36,6 +36,7 @@ export interface Theme {
   sectionScoping: boolean;
   tableOverflow: "scroll" | "wrap";
   outputLayout: "above" | "below";
+  pageWidth: "normal" | "wide" | "full";
   saveToExport: boolean;
 }
 
@@ -74,6 +75,7 @@ export const defaultTheme: Theme = {
   sectionScoping: true,
   tableOverflow: "scroll",
   outputLayout: "above",
+  pageWidth: "normal",
   saveToExport: false,
 };
 
@@ -106,7 +108,9 @@ export const updateTheme = (newTheme: any) => {
   if (newTheme.typography) setTheme("typography", (t) => ({ ...t, ...newTheme.typography }));
   if (newTheme.editor) setTheme("editor", (e) => ({ ...e, ...newTheme.editor }));
   if (newTheme.sectionScoping !== undefined) setTheme("sectionScoping", newTheme.sectionScoping);
+  if (newTheme.tableOverflow) setTheme("tableOverflow", newTheme.tableOverflow);
   if (newTheme.outputLayout) setTheme("outputLayout", newTheme.outputLayout);
+  if (newTheme.pageWidth) setTheme("pageWidth", newTheme.pageWidth);
   if (newTheme.saveToExport !== undefined) setTheme("saveToExport", newTheme.saveToExport);
 };
 
@@ -152,6 +156,8 @@ export const initTheme = () => {
     root.style.setProperty("--font-size-delta", theme.typography.headerDelta);
     root.style.setProperty("--header-margin-bottom", theme.typography.headerMarginBottom);
 
+    root.style.setProperty("--editor-max-code-height", theme.editor.maxCodeHeight);
+
     // Header Colors Logic
     const colors = theme.typography.headerColors || [];
     const h1Color = colors[0] || theme.colors.primary;
@@ -165,6 +171,24 @@ export const initTheme = () => {
     root.style.setProperty("--header-color-4", h4Color);
 
     root.style.setProperty("--table-overflow", theme.tableOverflow);
+
+    // Page width variables (header and content have slightly different widths)
+    if (theme.pageWidth === "wide") {
+      root.style.setProperty("--page-max-width-header", "62.5rem"); // max-w-250
+      root.style.setProperty("--page-margin-x-header", "auto");
+      root.style.setProperty("--page-max-width-content", "64rem"); // max-w-256
+      root.style.setProperty("--page-margin-x-content", "auto");
+    } else if (theme.pageWidth === "full") {
+      root.style.setProperty("--page-max-width-header", "100%");
+      root.style.setProperty("--page-margin-x-header", "2.5rem"); // mx-10
+      root.style.setProperty("--page-max-width-content", "100%");
+      root.style.setProperty("--page-margin-x-content", "2rem"); // mx-8
+    } else { // normal
+      root.style.setProperty("--page-max-width-header", "50.5rem"); // max-w-202
+      root.style.setProperty("--page-margin-x-header", "auto");
+      root.style.setProperty("--page-max-width-content", "52rem"); // max-w-208
+      root.style.setProperty("--page-margin-x-content", "auto");
+    }
 
     // Update meta theme color for browser UI (avoids white flash in new tabs)
     const metaTheme = document.getElementById('meta-theme-color');


### PR DESCRIPTION
## Add Page Width configuration to Theme dialog

Added a new "Page Width" option to the theme configuration with three presets:
- Normal (52rem) - default
- Wide (64rem) 
- Full Page - 100% width with side margins

### Implementation
- Uses CSS variables (`--page-max-width-*` and `--page-margin-x-*`) instead of dynamic classes to avoid component re-renders when theme changes
- Applied same CSS variable pattern to `editor.maxCodeHeight` for consistency
- Affects both the header/menu bar and the main cell container

### UI improvements
- Reorganized theme dialog sections:
  - Split "Behavior" section into "Layout" (Page Width, Table Overflow) and "Markdown" (Section Scoping)
  - Moved "Header Margin Bottom" from Typography to Spacing section
  - Renamed "Header Margin Bottom" to just "Header Margin"

Better semantic grouping and more consistent theme architecture overall.