### PR TITLE
adds code typography theme configuration options

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -436,8 +436,9 @@ const CodeEditor: Component<EditorProps> = (props) => {
       height: "auto",
       minHeight: "1.5rem",
       maxHeight: "var(--editor-max-code-height)",
-      fontSize: "1rem",
-      fontFamily: "var(--font-mono)",
+      fontSize: "var(--code-editor-font-size)",
+      fontFamily: "var(--code-font-family)",
+      fontWeight: "var(--code-font-weight)",
     },
     ".cm-content": {
       caretColor: "var(--accent) !important",
@@ -545,8 +546,9 @@ const CodeEditor: Component<EditorProps> = (props) => {
         border: "1px solid var(--color-foreground)",
         borderRadius: "0.125rem",
         padding: "0.25rem 0.5rem",
-        fontSize: "0.875rem",
-        fontFamily: "var(--font-mono)",
+        fontSize: "var(--code-base-font-size)",
+        fontFamily: "var(--code-font-family)",
+        fontWeight: "var(--code-font-weight)",
       },
       ".cm-panel.cm-search input": {
         "&::placeholder": {

--- a/src/components/ThemeDialog.tsx
+++ b/src/components/ThemeDialog.tsx
@@ -18,6 +18,7 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
     radii: { ...currentTheme.radii },
     spacing: { ...currentTheme.spacing },
     typography: { ...currentTheme.typography },
+    codeTypography: { ...currentTheme.codeTypography },
     editor: { ...currentTheme.editor },
     sectionScoping: currentTheme.sectionScoping,
     tableOverflow: currentTheme.tableOverflow,
@@ -615,9 +616,9 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
               />
             </div>
 
-            {/* Typography Section */}
+            {/* Markdown Typography Section */}
             <div class="space-y-2">
-              <h3 class="text-xs font-bold text-accent uppercase mb-2">Typography</h3>
+              <h3 class="text-xs font-bold text-accent uppercase mb-2">Markdown Typography</h3>
               <InputField
                 label="Font Family"
                 value={currentTheme.font}
@@ -637,6 +638,44 @@ const ThemeDialog: Component<ThemeDialogProps> = (props) => {
                 onChange={(v) => updateTheme({ typography: { ...currentTheme.typography, headerDelta: v } })}
                 placeholder="0.225rem"
                 step={0.0125}
+              />
+            </div>
+
+            {/* Code Typography Section */}
+            <div class="space-y-2">
+              <h3 class="text-xs font-bold text-accent uppercase mb-2">Code Typography</h3>
+              <InputField
+                label="Font Family"
+                value={currentTheme.codeTypography.fontFamily}
+                onChange={(v) => updateTheme({ codeTypography: { ...currentTheme.codeTypography, fontFamily: v } })}
+                placeholder='"JetBrains Mono Variable", monospace'
+              />
+              <NumberUnitInput
+                label="Base Font Size"
+                value={currentTheme.codeTypography.baseFontSize}
+                onChange={(v) => updateTheme({ codeTypography: { ...currentTheme.codeTypography, baseFontSize: v } })}
+                placeholder="0.875rem"
+                step={0.0625}
+              />
+              <NumberUnitInput
+                label="Inline Font Size"
+                value={currentTheme.codeTypography.inlineFontSize}
+                onChange={(v) => updateTheme({ codeTypography: { ...currentTheme.codeTypography, inlineFontSize: v } })}
+                placeholder="0.875rem"
+                step={0.0625}
+              />
+              <NumberUnitInput
+                label="Editor Font Size"
+                value={currentTheme.codeTypography.editorFontSize}
+                onChange={(v) => updateTheme({ codeTypography: { ...currentTheme.codeTypography, editorFontSize: v } })}
+                placeholder="1rem"
+                step={0.0625}
+              />
+              <InputField
+                label="Font Weight"
+                value={currentTheme.codeTypography.fontWeight}
+                onChange={(v) => updateTheme({ codeTypography: { ...currentTheme.codeTypography, fontWeight: v } })}
+                placeholder="400"
               />
             </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -233,8 +233,9 @@ body {
 }
 
 .milkdown .editor code {
-    font-family: var(--font-mono);
-    font-size: 0.875em;
+    font-family: var(--code-font-family);
+    font-size: var(--code-inline-font-size);
+    font-weight: var(--code-font-weight);
     background-color: color-mix(in srgb, var(--foreground) 20%, transparent);
     padding: 0.2em 0.4em;
     border-radius: var(--radius-sm);
@@ -247,13 +248,13 @@ body {
 
 /* Fix Tailwind resets for Prose (Presentation Mode) - Removed duplicates, now shared above */
 .prose code {
-    font-family: var(--font-mono) !important;
-    font-size: 0.875em !important;
+    font-family: var(--code-font-family) !important;
+    font-size: var(--code-inline-font-size) !important;
+    font-weight: var(--code-font-weight) !important;
     background-color: color-mix(in srgb, var(--accent) 8%, transparent);
     padding: 0.2em 0.5em;
     border-radius: var(--radius-sm);
     color: color-mix(in srgb, var(--secondary) 75%, transparent) !important;
-    font-weight: normal !important;
 }
 
 /* Code blocks (pre > code) - distinct block styling */
@@ -272,10 +273,10 @@ body {
     background-color: transparent !important;
     padding: 0 !important;
     border-radius: 0 !important;
-    font-family: var(--font-mono) !important;
-    font-size: 0.875em !important;
+    font-family: var(--code-font-family) !important;
+    font-size: var(--code-base-font-size) !important;
+    font-weight: var(--code-font-weight) !important;
     color: color-mix(in srgb, var(--secondary) 75%, transparent) !important;
-    font-weight: normal !important;
 }
 
 /* highlight.js theme - Duotone Dark matching CodeMirror */

--- a/src/lib/codemirror-tooling.ts
+++ b/src/lib/codemirror-tooling.ts
@@ -34,7 +34,7 @@ export const tooltipTheme = EditorView.theme({
     },
     ".cm-diagnostic": {
         padding: "0",
-        fontFamily: "var(--font-mono)"
+        fontFamily: "var(--code-font-family)"
     },
     ".cm-diagnostic-error": {
         paddingLeft: "0",
@@ -49,11 +49,11 @@ export const tooltipTheme = EditorView.theme({
         border: "1px solid var(--color-foreground)",
         borderRadius: "8px",
         boxShadow: "0 10px 15px -3px rgb(0 0 0 / 0.15), 0 4px 6px -4px rgb(0 0 0 / 0.15)",
-        fontFamily: "var(--font-mono)",
+        fontFamily: "var(--code-font-family)",
         zIndex: "9999"
     },
     ".cm-tooltip-autocomplete > ul": {
-        fontFamily: "var(--font-mono) !important",
+        fontFamily: "var(--code-font-family) !important",
         fontSize: "0.90rem !important",
         padding: "0.3rem 0 !important",
     },
@@ -65,7 +65,7 @@ export const tooltipTheme = EditorView.theme({
     },
     // Style completion section labels (function, property, variable)
     ".cm-tooltip.cm-tooltip-autocomplete > ul > completion-section": {
-        fontFamily: "var(--font-mono)",
+        fontFamily: "var(--code-font-family)",
         textTransform: "uppercase",
         fontSize: "0.77rem",
         color: "color-mix(in srgb, var(--color-secondary) 70%, transparent)",
@@ -155,7 +155,7 @@ const pythonCompletionSource: CompletionSource = async (context) => {
 
     // Don't show completions if no match found
     if (!word) return null;
-    
+
     // Show completions if:
     // 1. Explicitly requested (Ctrl+Space) 
     // 2. Text was typed (word.from !== word.to)
@@ -196,7 +196,7 @@ const pythonCompletionSource: CompletionSource = async (context) => {
     }
 };
 
-export const pythonIntellisense = autocompletion({ 
+export const pythonIntellisense = autocompletion({
     override: [pythonCompletionSource],
     activateOnTyping: true,
     closeOnBlur: true,

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -30,6 +30,13 @@ export interface Theme {
     headerColors?: string[];
     headerMarginBottom: string;
   };
+  codeTypography: {
+    fontFamily: string;
+    fontWeight: string;
+    baseFontSize: string;
+    inlineFontSize: string;
+    editorFontSize: string;
+  };
   editor: {
     maxCodeHeight: string;
   };
@@ -69,6 +76,13 @@ export const defaultTheme: Theme = {
     headerColors: ["#f38ba8", "#fab387", "#f9e2af", "#a6e3a1"],
     headerMarginBottom: "1.75rem",
   },
+  codeTypography: {
+    fontFamily: '"JetBrains Mono Variable", monospace',
+    fontWeight: "400",
+    baseFontSize: "0.875rem",
+    inlineFontSize: "0.875rem",
+    editorFontSize: "1rem",
+  },
   editor: {
     maxCodeHeight: "none",
   },
@@ -106,6 +120,7 @@ export const updateTheme = (newTheme: any) => {
   if (newTheme.radii) setTheme("radii", (r) => ({ ...r, ...newTheme.radii }));
   if (newTheme.spacing) setTheme("spacing", (s) => ({ ...s, ...newTheme.spacing }));
   if (newTheme.typography) setTheme("typography", (t) => ({ ...t, ...newTheme.typography }));
+  if (newTheme.codeTypography) setTheme("codeTypography", (ct) => ({ ...ct, ...newTheme.codeTypography }));
   if (newTheme.editor) setTheme("editor", (e) => ({ ...e, ...newTheme.editor }));
   if (newTheme.sectionScoping !== undefined) setTheme("sectionScoping", newTheme.sectionScoping);
   if (newTheme.tableOverflow) setTheme("tableOverflow", newTheme.tableOverflow);
@@ -155,6 +170,12 @@ export const initTheme = () => {
     root.style.setProperty("--font-size-base", theme.typography.fontSize);
     root.style.setProperty("--font-size-delta", theme.typography.headerDelta);
     root.style.setProperty("--header-margin-bottom", theme.typography.headerMarginBottom);
+
+    root.style.setProperty("--code-font-family", theme.codeTypography.fontFamily);
+    root.style.setProperty("--code-font-weight", theme.codeTypography.fontWeight);
+    root.style.setProperty("--code-base-font-size", theme.codeTypography.baseFontSize);
+    root.style.setProperty("--code-inline-font-size", theme.codeTypography.inlineFontSize);
+    root.style.setProperty("--code-editor-font-size", theme.codeTypography.editorFontSize);
 
     root.style.setProperty("--editor-max-code-height", theme.editor.maxCodeHeight);
 


### PR DESCRIPTION
## Add Code Typography configuration to Theme system

Added comprehensive code typography controls to theme configuration, separate from markdown typography settings.

### New configuration options
- Font Family - independent from markdown font
- Font Weight - applies to all code (inline, blocks, editor)
- Base Font Size - code blocks in markdown
- Inline Font Size - inline code in markdown
- Editor Font Size - code editor/cells

### Implementation
- Added `codeTypography` to Theme interface with 5 properties
- Created CSS variables: `--code-font-family`, `--code-font-weight`, `--code-base-font-size`, `--code-inline-font-size`, `--code-editor-font-size`
- Updated CodeEditor, inline code styles, code blocks, and CodeMirror tooltips to use new variables
- All settings persist with app-wide and session-specific scopes

### UI changes
- Renamed "Typography" section to "Markdown Typography" in theme dialog
- Added new "Code Typography" section underneath with 5 config inputs
- Matches existing theme dialog styling

### Design decision
Changed inline code and code blocks from `0.875em` (relative to parent text size) to `0.875rem` (absolute). This allows code typography to be configured independently of markdown typography, which makes more sense for a dedicated code typography system.

Defaults match current values so no visual changes unless configured.