### PR TITLE
adds line wrap toggle to code visibility dialog menu and fixes scrollbar theming in chrome and edge browsers

### DIFF
--- a/src/components/CodeCell.tsx
+++ b/src/components/CodeCell.tsx
@@ -165,12 +165,12 @@ const CodeCell: Component<CodeCellProps> = (props) => {
         )}>
            {/* Line numbers gutter could go here */}
            <div class={clsx(
-             "w-10 bg-background border-r border-foreground flex flex-col items-center pt-5.5 pr-1.5 text-xs select-none font-mono",
+             "w-10 bg-background border-r border-foreground flex flex-col items-center pt-5.5 pr-1.5 text-xs select-none font-mono shrink-0",
              props.cell.outputs?.executionKernelId === kernel.id ? "text-secondary/50 font-bold" : "text-foreground"
            )}>
               [{props.index + 1}]:
            </div>
-           <div class="flex-1 bg-accent/2 relative">
+           <div class="flex-1 min-w-0 bg-accent/2 relative">
              <CodeEditor
                value={props.cell.content}
                onChange={(val) => actions.updateCell(props.cell.id, val)}

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -631,7 +631,6 @@ const CodeEditor: Component<EditorProps> = (props) => {
       ...historyKeymap,
       ...searchKeymap
     ]),
-    EditorView.lineWrapping
   ];
   createExtension(extensionsConfig);
   
@@ -641,6 +640,11 @@ const CodeEditor: Component<EditorProps> = (props) => {
   // Reactive line numbers (toggleable via settings)
   createExtension(createMemo(() => {
     return codeVisibility.showLineNumbers ? lineNumbers() : [];
+  }));
+  
+  // Reactive line wrapping (toggleable via settings)
+  createExtension(createMemo(() => {
+    return codeVisibility.lineWrap ? EditorView.lineWrapping : [];
   }));
   
   // Reactive Linter

--- a/src/components/CodeVisibilityDialog.tsx
+++ b/src/components/CodeVisibilityDialog.tsx
@@ -1,5 +1,5 @@
 import { type Component, createSignal, createEffect, Show } from "solid-js";
-import { X, Code, EyeOff, TriangleAlert, Terminal, FileOutput, AlertCircle, CircleDot, ArrowUp, ArrowDown, Hash } from "lucide-solid";
+import { X, Code, EyeOff, TriangleAlert, Terminal, FileOutput, AlertCircle, CircleDot, ArrowUp, ArrowDown, Hash, WrapText } from "lucide-solid";
 import clsx from "clsx";
 import { 
   codeVisibility, 
@@ -25,6 +25,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
     showStatusDot: codeVisibility.showStatusDot,
     saveToExport: codeVisibility.saveToExport,
     showLineNumbers: codeVisibility.showLineNumbers,
+    lineWrap: codeVisibility.lineWrap,
   });
 
   // Local state for output layout (above/below)
@@ -41,6 +42,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       showStatusDot: codeVisibility.showStatusDot,
       saveToExport: codeVisibility.saveToExport,
       showLineNumbers: codeVisibility.showLineNumbers,
+      lineWrap: codeVisibility.lineWrap,
     });
     setLocalOutputLayout(currentTheme.outputLayout);
   });
@@ -60,6 +62,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
     updateVisibility("showStatusDot", settings.showStatusDot);
     updateVisibility("saveToExport", settings.saveToExport);
     updateVisibility("showLineNumbers", settings.showLineNumbers);
+    updateVisibility("lineWrap", settings.lineWrap);
     // Persist visibility to localStorage
     saveVisibilitySettings();
     // Update theme output layout
@@ -82,7 +85,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
     icon: Component<{ size?: number }>;
     iconColor: string;
     hasPositionToggle?: boolean;
-    hasLineNumbersToggle?: boolean;
+    hasEditorToggles?: boolean;
   }> = (itemProps) => (
     <div 
       class="flex items-center gap-2 py-1.5 px-2 rounded-sm hover:bg-foreground/50 transition-colors group cursor-pointer"
@@ -123,7 +126,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       </Show>
       
       {/* Line numbers toggle for code editor */}
-      <Show when={itemProps.hasLineNumbersToggle && localSettings()[itemProps.itemKey]}>
+      <Show when={itemProps.hasEditorToggles && localSettings()[itemProps.itemKey]}>
         <button
           type="button"
           class="flex items-center gap-1 px-1.5 py-0.5 text-xs text-secondary/60 hover:text-secondary hover:bg-foreground rounded transition-colors"
@@ -135,6 +138,18 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
         >
           <Hash size={12} />
           <Show when={localSettings().showLineNumbers} fallback="off">on</Show>
+        </button>
+        <button
+          type="button"
+          class="flex items-center gap-1 px-1.5 py-0.5 text-xs text-secondary/60 hover:text-secondary hover:bg-foreground rounded transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            toggle("lineWrap");
+          }}
+          title={localSettings().lineWrap ? "Disable line wrap" : "Enable line wrap"}
+        >
+          <WrapText size={12} />
+          <Show when={localSettings().lineWrap} fallback="off">on</Show>
         </button>
       </Show>
     </div>
@@ -166,7 +181,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
           <div class="flex-1 p-4 overflow-y-auto border-b sm:border-b-0 sm:border-r border-foreground">
             <h3 class="text-xs font-bold text-accent uppercase mb-2">Show / Hide Elements</h3>
             <div class="space-y-0.5">
-              <CheckboxRow itemKey="showCode" label="Code Editor" icon={Code} iconColor="text-accent" hasLineNumbersToggle={true} />
+              <CheckboxRow itemKey="showCode" label="Code Editor" icon={Code} iconColor="text-accent" hasEditorToggles={true} />
               <CheckboxRow itemKey="showStatusDot" label="Status Indicator" icon={CircleDot} iconColor="text-green-500" />
               <CheckboxRow itemKey="showStdout" label="Standard Output" icon={Terminal} iconColor="text-secondary" hasPositionToggle={true} />
               <CheckboxRow itemKey="showResult" label="Return Value" icon={FileOutput} iconColor="text-secondary/70" />

--- a/src/index.css
+++ b/src/index.css
@@ -44,12 +44,6 @@ body {
 }
 
 /* Scrollbar styling */
-/* Firefox */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--primary) transparent;
-}
-
 /* Chrome, Edge, Safari */
 ::-webkit-scrollbar {
   width: 5px;
@@ -59,16 +53,19 @@ body {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--primary);
+  background: var(--foreground);
   border-radius: var(--radius-lg);
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--primary);
 }
-::-webkit-scrollbar-button {
-  display: none;
-  width: 0;
-  height: 0;
+
+/* Firefox only - apply standard scrollbar properties */
+@supports not selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--primary) transparent;
+  }
 }
 
 /* Utilities */

--- a/src/lib/codeVisibility.ts
+++ b/src/lib/codeVisibility.ts
@@ -10,6 +10,7 @@ export interface CodeVisibilitySettings {
     showStatusDot: boolean;
     saveToExport: boolean;
     showLineNumbers: boolean;
+    lineWrap: boolean;
 }
 
 const STORAGE_KEY = "pynote-code-visibility";
@@ -53,6 +54,7 @@ const defaultSettings: CodeVisibilitySettings = {
     showStatusDot: true,
     saveToExport: false,
     showLineNumbers: false,
+    lineWrap: true,
 };
 
 // Load from localStorage
@@ -295,6 +297,7 @@ export const getEffectiveVisibility = (
             showStatusDot: cellMetadata.showStatusDot ?? settings.showStatusDot,
             saveToExport: settings.saveToExport, // This is app-level only
             showLineNumbers: settings.showLineNumbers, // This is app-level only
+            lineWrap: settings.lineWrap, // This is app-level only
         };
     }
 


### PR DESCRIPTION
**Add line wrap toggle for code editor**

Added a line wrap toggle to the code visibility dialog, right next to the line numbers toggle in the editor settings row. Uses CodeMirror's built-in `EditorView.lineWrapping` extension.

When line wrap is off, long lines scroll horizontally instead of wrapping. Fixed a flex layout issue (`min-w-0`) that was preventing horizontal scrolling from working properly.