### PR TITLE
migrates vitest suite and adds architected Playwright e2e layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ build
 node_modules
 *.local
 
+# Playwright e2e artifacts
+/reports/e2e-html/
+/reports/e2e-artifacts/
+/reports/e2e-junit.xml
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,81 @@
+# End-to-End Tests
+
+Browser-level tests for the PyNote notebook editor, running on
+[Playwright](https://playwright.dev/) against the real Vite dev server and a
+real Pyodide kernel. These cover whole user journeys (author a cell, run it,
+reload, undo) that the [Vitest suite](../src/test/README.md) cannot.
+
+## Running tests
+
+From the project root:
+
+| Command                                  | What it does                                  |
+| ---------------------------------------- | --------------------------------------------- |
+| `npm run test:e2e`                       | Run the full suite (starts the dev server).   |
+| `npm run test:e2e -- --headed`           | Watch it drive a visible browser.             |
+| `npm run test:e2e -- --debug`            | Step through with the Playwright Inspector.   |
+| `npm run test:e2e -- happy-path`         | Run a single spec by filename fragment.       |
+| `npm run test:e2e -- -g "undo"`          | Run tests whose title matches.                |
+
+First-time setup installs the browser binary:
+
+```sh
+npx playwright install chromium
+```
+
+The HTML report lands at `reports/e2e-html`; failure traces, screenshots, and
+videos at `reports/e2e-artifacts`.
+
+## Layout
+
+```
+e2e/
+  tests/                 # specs — one file per user journey
+    happy-path.spec.ts
+    session-persistence.spec.ts
+    undo-redo.spec.ts
+    themed-notebook.spec.ts
+  pages/
+    NotebookPage.ts      # page object: all selectors + interactions
+  support/
+    fixtures.ts          # custom `test`/`expect` with a `notebook` fixture
+    selectors.ts         # bridges the app's shared testid registry
+```
+
+Configuration: [playwright.config.ts](../playwright.config.ts).
+
+## Conventions
+
+These exist to keep the suite from rotting into brittle, flaky seams.
+
+1. **Import `test`/`expect` from `support/fixtures`, never from
+   `@playwright/test`.** Every spec then receives a ready `notebook` page
+   object and shares the same setup.
+
+2. **Specs never contain selectors.** All locators and interactions live on
+   `NotebookPage`. A DOM change is fixed in one place, not across every spec.
+
+3. **Selectors come from the shared testid registry**
+   ([src/lib/testids.ts](../src/lib/testids.ts)). The app sets
+   `data-testid={TESTID.x}` and tests resolve it via `page.getByTestId`. Because
+   both sides import the same map, renaming a hook is a compile error, not a
+   silent break. Add a new hook only when no stable role/text selector exists.
+
+4. **Waits are web-first — never `waitForTimeout`.** Use
+   `expect(locator).toBeVisible()`, attribute assertions, and `expect.poll`.
+   Kernel readiness is awaited via the `data-status="ready"` attribute on the
+   status indicator (`NotebookPage.waitForKernelReady`).
+
+5. **Assertions are unconditional.** No `if (maybe) expect(...)`; a test that
+   can silently pass without verifying anything is worse than no test.
+
+6. **One journey per spec file**, wrapped in a `test.describe` named for the
+   journey.
+
+## Adding a test
+
+1. If you need a new element hook, add it to
+   [src/lib/testids.ts](../src/lib/testids.ts) and set `data-testid` on the
+   element in the component.
+2. Add the locator/action to [pages/NotebookPage.ts](pages/NotebookPage.ts).
+3. Write the spec in `tests/`, importing from `../support/fixtures`.

--- a/e2e/pages/NotebookPage.ts
+++ b/e2e/pages/NotebookPage.ts
@@ -1,0 +1,169 @@
+import { type Page, type Locator, expect } from "@playwright/test";
+import { TESTID } from "../support/selectors";
+
+/**
+ * Page object for the notebook editor. Encapsulates every selector and
+ * interaction so specs read as user intent ("add a code cell, run it, read the
+ * output") and any DOM change is absorbed here rather than across every test.
+ *
+ * Conventions:
+ * - Locators are exposed as getters so they are re-resolved on each access
+ *   (Solid re-renders cells; stale handles would flake).
+ * - Waits are web-first (`expect(locator).toBeVisible()`, attribute assertions)
+ *   — never arbitrary `waitForTimeout`.
+ */
+export class NotebookPage {
+  constructor(private readonly page: Page) {}
+
+  // --- Core locators ---------------------------------------------------------
+
+  get root(): Locator {
+    return this.page.getByTestId(TESTID.appRoot);
+  }
+
+  get kernelStatus(): Locator {
+    return this.page.getByTestId(TESTID.kernelStatus);
+  }
+
+  get addCodeCellButton(): Locator {
+    return this.page.getByTestId(TESTID.addCodeCell);
+  }
+
+  get addMarkdownCellButton(): Locator {
+    return this.page.getByTestId(TESTID.addMarkdownCell);
+  }
+
+  get cells(): Locator {
+    return this.page.getByTestId(TESTID.cell);
+  }
+
+  get outputs(): Locator {
+    return this.page.getByTestId(TESTID.cellOutput);
+  }
+
+  /** The CodeMirror editing surface inside the nth cell (0-based). */
+  cellEditor(index: number): Locator {
+    return this.cells.nth(index).locator(".cm-editor");
+  }
+
+  // --- Navigation / lifecycle ------------------------------------------------
+
+  /**
+   * Navigate to the app (optionally with a query string such as
+   * `?theme=magic_dark`) and wait until the shell has mounted.
+   */
+  async goto(query = ""): Promise<void> {
+    await this.page.goto(`/${query}`);
+    await expect(this.root).toBeVisible();
+  }
+
+  /**
+   * Wait until the Pyodide kernel reports ready. The status element carries a
+   * `data-status` attribute mirroring `kernel.status`, so this is a precise,
+   * non-flaky wait rather than polling visible text.
+   */
+  async waitForKernelReady(timeout = 60_000): Promise<void> {
+    await expect(this.kernelStatus).toHaveAttribute("data-status", "ready", {
+      timeout,
+    });
+  }
+
+  /** Navigate and wait for both the shell and a ready kernel. */
+  async open(query = ""): Promise<void> {
+    await this.goto(query);
+    await this.waitForKernelReady();
+  }
+
+  // --- Actions ---------------------------------------------------------------
+
+  async addCodeCell(): Promise<void> {
+    const before = await this.cells.count();
+    await this.addCodeCellButton.click();
+    await expect(this.cells).toHaveCount(before + 1);
+  }
+
+  async addMarkdownCell(): Promise<void> {
+    const before = await this.cells.count();
+    await this.addMarkdownCellButton.click();
+    await expect(this.cells).toHaveCount(before + 1);
+  }
+
+  /** Type source into a cell's editor. */
+  async typeInCell(index: number, source: string): Promise<void> {
+    const editor = this.cellEditor(index);
+    await editor.click();
+    await this.page.keyboard.type(source);
+  }
+
+  /** Run the focused cell and keep selection (Ctrl+Enter). */
+  async runFocusedCell(): Promise<void> {
+    await this.page.keyboard.press("Control+Enter");
+  }
+
+  /**
+   * Leave edit mode (Esc). Adding a cell focuses its editor, which captures
+   * Ctrl+Z for its own text history; the global notebook undo only fires in
+   * command mode, so callers exit edit mode first.
+   */
+  async exitEditMode(): Promise<void> {
+    await this.page.keyboard.press("Escape");
+  }
+
+  async undo(): Promise<void> {
+    await this.page.keyboard.press("Control+z");
+  }
+
+  async redo(): Promise<void> {
+    await this.page.keyboard.press("Control+Shift+z");
+  }
+
+  // --- Assertions / reads ----------------------------------------------------
+
+  async cellCount(): Promise<number> {
+    return this.cells.count();
+  }
+
+  /** The session id from the `?session=` query param the app assigns on load. */
+  sessionId(): Promise<string | null> {
+    return this.page.evaluate(
+      () => new URLSearchParams(window.location.search).get("session"),
+    );
+  }
+
+  /**
+   * Number of cells in the autosaved session payload for `id`, or -1 if nothing
+   * is persisted yet. Lets tests wait for the debounced autosave to flush
+   * before reloading.
+   */
+  persistedCellCount(id: string): Promise<number> {
+    return this.page.evaluate((sessionId) => {
+      const raw = localStorage.getItem(`pynote-session-${sessionId}`);
+      if (!raw) return -1;
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed?.cells) ? parsed.cells.length : -1;
+      } catch {
+        return -1;
+      }
+    }, id);
+  }
+
+  /** The combined visible text of all output regions. */
+  async outputText(): Promise<string> {
+    const count = await this.outputs.count();
+    const parts: string[] = [];
+    for (let i = 0; i < count; i++) {
+      parts.push((await this.outputs.nth(i).textContent()) ?? "");
+    }
+    return parts.join("\n");
+  }
+
+  /** Read a CSS custom property set on :root (used for theme assertions). */
+  cssVariable(name: string): Promise<string> {
+    return this.page.evaluate(
+      (varName) =>
+        document.documentElement.style.getPropertyValue(varName).trim(),
+      name,
+    );
+  }
+}

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -1,0 +1,22 @@
+import { test as base } from "@playwright/test";
+import { NotebookPage } from "../pages/NotebookPage";
+
+/**
+ * Custom fixtures layered on top of Playwright's base test. Importing `test`
+ * and `expect` from here (instead of `@playwright/test`) gives every spec a
+ * ready-made `notebook` page object, keeping specs free of setup boilerplate.
+ *
+ * Add new page objects / shared state as additional fixtures here so the wiring
+ * stays in one place.
+ */
+type Fixtures = {
+  notebook: NotebookPage;
+};
+
+export const test = base.extend<Fixtures>({
+  notebook: async ({ page }, use) => {
+    await use(new NotebookPage(page));
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/support/selectors.ts
+++ b/e2e/support/selectors.ts
@@ -1,0 +1,14 @@
+// Bridges the application's shared testid registry into the Playwright suite.
+// Tests and page objects never hard-code raw `data-testid` strings; they go
+// through `byTestId` (or Playwright's built-in `getByTestId`, configured in
+// playwright.config.ts to use the `data-testid` attribute). Importing the same
+// `TESTID` map the app uses means a renamed hook fails to compile rather than
+// silently breaking a selector at runtime.
+import { TESTID } from "../../src/lib/testids";
+
+export { TESTID };
+
+/** Build a CSS attribute selector for a registered testid. */
+export function byTestId(id: (typeof TESTID)[keyof typeof TESTID]): string {
+  return `[data-testid="${id}"]`;
+}

--- a/e2e/tests/happy-path.spec.ts
+++ b/e2e/tests/happy-path.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "../support/fixtures";
+
+// The core authoring loop: add a code cell, run an expression, see its result.
+test.describe("happy path", () => {
+  test("add a code cell, execute it, and see output", async ({ notebook }) => {
+    await notebook.open();
+
+    await notebook.addCodeCell();
+    const lastIndex = (await notebook.cellCount()) - 1;
+
+    await notebook.typeInCell(lastIndex, "1 + 1");
+    await notebook.runFocusedCell();
+
+    await expect(notebook.outputs.last()).toContainText("2", {
+      timeout: 60_000,
+    });
+  });
+});

--- a/e2e/tests/session-persistence.spec.ts
+++ b/e2e/tests/session-persistence.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "../support/fixtures";
+
+// Autosaved notebook state must survive a full page reload.
+test.describe("session persistence", () => {
+  test("an added cell persists through page reload", async ({ notebook, page }) => {
+    await notebook.open();
+
+    const sessionId = await notebook.sessionId();
+    expect(sessionId).toBeTruthy();
+
+    // Make a structural change that the app autosaves to localStorage.
+    await notebook.addCodeCell();
+    const expectedCount = await notebook.cellCount();
+
+    // Wait for the debounced autosave to flush the new cell to storage before
+    // reloading — otherwise we would race the 300ms write.
+    await expect
+      .poll(() => notebook.persistedCellCount(sessionId!), { timeout: 15_000 })
+      .toBe(expectedCount);
+
+    await page.reload();
+    await notebook.waitForKernelReady();
+
+    // The restored notebook has the same cells, under the same session.
+    expect(await notebook.sessionId()).toBe(sessionId);
+    await expect(notebook.cells).toHaveCount(expectedCount);
+  });
+});
+

--- a/e2e/tests/themed-notebook.spec.ts
+++ b/e2e/tests/themed-notebook.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "../support/fixtures";
+
+// A `?theme=` query param injects a built-in theme's CSS variables before the
+// kernel loads, so we assert on `:root` custom properties directly.
+test.describe("themed notebook", () => {
+  test("loading with ?theme=magic_dark applies theme CSS variables", async ({
+    notebook,
+  }) => {
+    // Theme is applied synchronously on mount — no need to wait for the kernel.
+    await notebook.goto("?theme=magic_dark");
+
+    await expect.poll(() => notebook.cssVariable("--background")).toBe("#0b0a0f");
+    expect(await notebook.cssVariable("--primary")).toBe("#b9bbfe");
+  });
+});

--- a/e2e/tests/undo-redo.spec.ts
+++ b/e2e/tests/undo-redo.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "../support/fixtures";
+
+// Undo/redo must round-trip a structural change (adding a cell).
+test.describe("undo / redo", () => {
+  test("undo removes an added cell and redo restores it", async ({ notebook }) => {
+    await notebook.open();
+
+    const initial = await notebook.cellCount();
+
+    await notebook.addCodeCell();
+    const afterAdd = initial + 1;
+    await expect(notebook.cells).toHaveCount(afterAdd);
+
+    // The new cell's editor is focused; leave edit mode so the global
+    // notebook undo (not the editor's text undo) handles the keystroke.
+    await notebook.exitEditMode();
+
+    await notebook.undo();
+    await expect(notebook.cells).toHaveCount(initial);
+
+    await notebook.redo();
+    await expect(notebook.cells).toHaveCount(afterAdd);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "uplot": "^1.6.32"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@solidjs/testing-library": "^0.8.10",
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/vite": "^4.1.18",
@@ -2085,6 +2086,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ocavue"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6606,6 +6623,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:ci": "vitest run --coverage"
+    "test:ci": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",
@@ -66,6 +67,7 @@
     "uplot": "^1.6.32"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/vite": "^4.1.18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// End-to-end configuration. The suite drives the real Vite dev server with a
+// real Pyodide kernel, so timeouts are generous and runs are serial (a single
+// shared WASM kernel does not parallelize cleanly).
+export default defineConfig({
+  testDir: './e2e/tests',
+  // Pyodide cold-starts the kernel, so individual tests need headroom.
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  // One kernel, one tab: keep runs deterministic rather than fast.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // Test artifacts live under reports/ alongside the vitest coverage output.
+  outputDir: './reports/e2e-artifacts',
+  reporter: process.env.CI
+    ? [['list'], ['html', { outputFolder: './reports/e2e-html', open: 'never' }], ['junit', { outputFile: './reports/e2e-junit.xml' }]]
+    : [['list'], ['html', { outputFolder: './reports/e2e-html', open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:5173',
+    // Stable hooks come from the shared registry (src/lib/testids.ts).
+    testIdAttribute: 'data-testid',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Notebook from "./components/Notebook";
 import { kernel } from "./lib/pyodide";
 import { initTheme } from "./lib/theme";
 import { actions } from "./lib/store";
+import { TESTID } from "./lib/testids";
 
 const App: Component = () => {
   initTheme();
@@ -14,6 +15,7 @@ const App: Component = () => {
   return (
     <div 
       class="min-h-screen bg-background text-secondary transition-colors duration-300 font-mono"
+      data-testid={TESTID.appRoot}
       onMouseDown={() => actions.setActiveCell(null)}
     >
       <Notebook />

--- a/src/__tests__/integration/chart-theming.test.ts
+++ b/src/__tests__/integration/chart-theming.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'vitest';
+import { updateTheme, currentTheme, defaultTheme } from '../../lib/theme';
+import {
+  getObservablePlotTheme,
+  getUPlotTheme,
+  getFrappeTheme,
+  generateColorPalette,
+  withAlpha,
+} from '../../lib/chart-theme';
+
+describe('theme-to-CSS-variables pipeline', () => {
+  test('updateTheme updates the reactive store which initTheme would read', () => {
+    // updateTheme modifies currentTheme (the reactive store).
+    // initTheme creates a createEffect that reads from currentTheme and sets CSS vars.
+    // We verify the store side: that updateTheme correctly merges partial updates.
+    updateTheme({ colors: { primary: '#abcdef', accent: '#123456' } });
+
+    // currentTheme should reflect the updates
+    expect(currentTheme.colors.primary).toBe('#abcdef');
+    expect(currentTheme.colors.accent).toBe('#123456');
+    // Non-updated fields should retain defaults
+    expect(currentTheme.colors.background).toBe(defaultTheme.colors.background);
+
+    // Restore
+    updateTheme(defaultTheme);
+  });
+});
+
+describe('chart theme generators use current theme colors', () => {
+  test('getObservablePlotTheme derives from currentTheme', () => {
+    // Set a known accent/secondary so assertions are deterministic
+    updateTheme({
+      colors: {
+        accent: '#aabbcc',
+        secondary: '#112233',
+        background: '#000000',
+        primary: '#ff0000',
+      },
+    });
+
+    const theme = getObservablePlotTheme();
+    expect(theme.style.background).toBe('#000000');
+    expect(theme.marks.stroke).toBe('#aabbcc');
+    expect(theme.marks.fill).toBe(withAlpha('#aabbcc', 0.3));
+    expect(theme.colorPalette).toEqual(generateColorPalette('#aabbcc', 8));
+    // Axes use color-mix with secondary
+    expect(theme.axes.stroke).toContain('#112233');
+  });
+
+  test('getUPlotTheme and getFrappeTheme have correct structure', () => {
+    updateTheme({ colors: { accent: '#ff5500', primary: '#00ff00' } });
+
+    const uplot = getUPlotTheme();
+    expect(uplot.series.stroke).toBe('#ff5500');
+    expect(uplot.cursor.stroke).toBe('#00ff00');
+    expect(uplot.colorPalette).toHaveLength(8);
+    expect(uplot.axes.tickSize).toBe(5);
+
+    const frappe = getFrappeTheme();
+    expect(frappe.colors).toHaveLength(8);
+    expect(frappe.colors[0]).toBe('#ff5500');
+    // Tooltip formatters work
+    expect(frappe.tooltipOptions.formatTooltipX('Jan')).toBe('Jan');
+    expect(frappe.tooltipOptions.formatTooltipY(1234)).toBe('1,234');
+    expect(frappe.tooltipOptions.formatTooltipY(null as any)).toBe('');
+    expect(frappe.tooltipOptions.formatTooltipX(null as any)).toBe('');
+
+    // Restore defaults
+    updateTheme(defaultTheme);
+  });
+});

--- a/src/__tests__/integration/execution-queue.test.ts
+++ b/src/__tests__/integration/execution-queue.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Hoist mock so it's available for vi.mock
+const mockKernel = vi.hoisted(() => ({
+  _status: 'ready' as string,
+  get status() { return this._status; },
+  clearCellState: vi.fn(),
+  setCellContext: vi.fn(),
+}));
+
+vi.mock('../../lib/pyodide', () => ({
+  kernel: mockKernel,
+}));
+
+// Import store AFTER mock is in place
+import { actions, notebookStore } from '../../lib/store';
+import type { CellData } from '../../lib/store';
+
+function loadTwoCells(): [string, string] {
+  const cells: CellData[] = [
+    { id: 'cell-A', type: 'code', content: 'x = 1' },
+    { id: 'cell-B', type: 'code', content: 'print(x)' },
+  ];
+  actions.loadNotebook(cells, 'test.ipynb');
+  return ['cell-A', 'cell-B'];
+}
+
+beforeEach(() => {
+  mockKernel._status = 'ready';
+  mockKernel.clearCellState.mockClear();
+  mockKernel.setCellContext.mockClear();
+  // Start fresh — loadNotebook resets cells/history but not executionQueue
+  actions.loadNotebook([], 'test.ipynb');
+  actions.resetExecutionState();
+});
+
+describe('execution queue logic', () => {
+  test('queue_all: queues when another cell is running', () => {
+    const [a, b] = loadTwoCells();
+    actions.setExecutionMode('queue_all');
+
+    // Simulate cell A already running
+    actions.setCellRunning(a, true);
+
+    const mockRun = vi.fn().mockResolvedValue(undefined);
+    actions.runCell(b, mockRun);
+
+    // Cell B should be queued
+    expect(notebookStore.executionQueue).toContain(b);
+    // runKernel should NOT have been called for cell B
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  test('hybrid: queues only when the previous cell is running or queued', () => {
+    const [a, b] = loadTwoCells();
+    actions.setExecutionMode('hybrid');
+
+    // Previous cell (A) is running → B should queue
+    actions.setCellRunning(a, true);
+
+    const mockRun = vi.fn().mockResolvedValue(undefined);
+    actions.runCell(b, mockRun);
+
+    expect(notebookStore.executionQueue).toContain(b);
+  });
+
+  test('direct: never queues regardless of running state', () => {
+    const [a, b] = loadTwoCells();
+    actions.setExecutionMode('direct');
+
+    // Another cell is running
+    actions.setCellRunning(a, true);
+
+    const mockRun = vi.fn().mockResolvedValue(undefined);
+    actions.runCell(b, mockRun);
+
+    // Direct mode: cell B starts immediately (not queued)
+    expect(notebookStore.executionQueue).not.toContain(b);
+    // The cell should now be running (executeCell sets isRunning synchronously)
+    const cellB = notebookStore.cells.find(c => c.id === b);
+    expect(cellB?.isRunning).toBe(true);
+  });
+});

--- a/src/__tests__/integration/kernel-routing.test.ts
+++ b/src/__tests__/integration/kernel-routing.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { kernel } from '../../lib/pyodide';
+
+// Access private internals for testing — these are Maps on the Kernel instance
+const k = kernel as any;
+
+beforeEach(() => {
+  k.listeners.clear();
+  k.componentListeners.clear();
+  k.componentToCellMap.clear();
+  k.currentCellContext = null;
+});
+
+describe('kernel message routing', () => {
+  test('listener receives messages matching its ID', () => {
+    const handler = vi.fn();
+    k.listeners.set('exec_42', handler);
+
+    // Simulate worker onmessage (if worker were set)
+    // Since worker is null, we call the handler directly to test routing logic
+    const msg = { type: 'stdout', id: 'exec_42', content: 'hello' };
+    // Verify the handler is mapped
+    expect(k.listeners.has('exec_42')).toBe(true);
+    k.listeners.get('exec_42')!(msg);
+    expect(handler).toHaveBeenCalledWith(msg);
+
+    // Different ID: handler should NOT be triggered
+    expect(k.listeners.has('exec_99')).toBe(false);
+  });
+
+  test('component update dispatches to component listener', () => {
+    const callback = vi.fn();
+    kernel.setCellContext('cell-1');
+    kernel.registerComponentListener('slider-1', callback);
+
+    // Verify registration
+    expect(k.componentListeners.has('slider-1')).toBe(true);
+    expect(k.componentToCellMap.get('slider-1')).toBe('cell-1');
+
+    // Simulate component_update
+    k.componentListeners.get('slider-1')!({ value: 42 });
+    expect(callback).toHaveBeenCalledWith({ value: 42 });
+  });
+
+  test('race condition: old cleanup does not remove re-registered listener', () => {
+    const oldCallback = vi.fn();
+    const newCallback = vi.fn();
+
+    // Step 1: Cell executes, registers component
+    kernel.setCellContext('cell-1');
+    kernel.registerComponentListener('comp-1', oldCallback);
+    expect(k.componentListeners.get('comp-1')).toBe(oldCallback);
+
+    // Step 2: Cell re-executes — clearCellState removes old components
+    kernel.clearCellState('cell-1');
+    expect(k.componentListeners.has('comp-1')).toBe(false);
+
+    // Step 3: New execution starts, sets context, registers same component ID
+    kernel.setCellContext('cell-1');
+    kernel.registerComponentListener('comp-1', newCallback);
+    expect(k.componentListeners.get('comp-1')).toBe(newCallback);
+
+    // Step 4: Old component finally unmounts (async cleanup fires late)
+    kernel.unregisterComponentListener('comp-1');
+
+    // The guard in unregisterComponentListener checks:
+    //   cellId === currentCellContext → don't remove (it's the new registration)
+    expect(k.componentListeners.has('comp-1')).toBe(true);
+    expect(k.componentListeners.get('comp-1')).toBe(newCallback);
+  });
+});

--- a/src/__tests__/integration/undo-redo.test.ts
+++ b/src/__tests__/integration/undo-redo.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { actions, notebookStore } from '../../lib/store';
+import type { CellData } from '../../lib/store';
+
+beforeEach(() => {
+  // Start with a clean notebook
+  actions.loadNotebook([], 'test.ipynb');
+});
+
+describe('global undo/redo roundtrip', () => {
+  test('add cell → undo removes it → redo restores it', () => {
+    actions.addCell('code');
+    const addedId = notebookStore.cells[0].id;
+    expect(notebookStore.cells).toHaveLength(1);
+
+    actions.undo();
+    expect(notebookStore.cells).toHaveLength(0);
+
+    actions.redo();
+    expect(notebookStore.cells).toHaveLength(1);
+    // The restored cell has the same ID
+    expect(notebookStore.cells[0].id).toBe(addedId);
+  });
+
+  test('delete cell → undo restores with original content', () => {
+    // Seed a cell with content via loadNotebook
+    const seed: CellData = { id: 'md-1', type: 'markdown', content: 'Hello **world**' };
+    actions.loadNotebook([seed], 'test.ipynb');
+    expect(notebookStore.cells).toHaveLength(1);
+
+    actions.deleteCell('md-1');
+    expect(notebookStore.cells).toHaveLength(0);
+
+    actions.undo();
+    expect(notebookStore.cells).toHaveLength(1);
+    expect(notebookStore.cells[0].content).toBe('Hello **world**');
+    expect(notebookStore.cells[0].id).toBe('md-1');
+  });
+
+  test('batch undo: multiple adds become a single undo unit', () => {
+    actions.beginBatch();
+    actions.addCell('code');
+    actions.addCell('markdown');
+    actions.addCell('code');
+    actions.endBatch();
+
+    expect(notebookStore.cells).toHaveLength(3);
+
+    // One undo reverts all three adds
+    actions.undo();
+    expect(notebookStore.cells).toHaveLength(0);
+
+    // One redo restores all three
+    actions.redo();
+    expect(notebookStore.cells).toHaveLength(3);
+  });
+
+  test('redo at end of history is a no-op', () => {
+    actions.addCell('code');
+    const count = notebookStore.cells.length;
+    const idx = notebookStore.historyIndex;
+
+    actions.redo(); // Already at the tip
+    expect(notebookStore.cells).toHaveLength(count);
+    expect(notebookStore.historyIndex).toBe(idx);
+  });
+});

--- a/src/__tests__/unit/code-visibility.test.ts
+++ b/src/__tests__/unit/code-visibility.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import {
+  getEffectiveVisibility,
+  setCellShowAll,
+  setVisibilitySettings,
+  resetUserOverride,
+  clearAllOverrides,
+  codeVisibility,
+} from '../../lib/codeVisibility';
+import type { CellCodeVisibility } from '../../lib/store';
+
+beforeEach(() => {
+  clearAllOverrides();
+  resetUserOverride();
+  setVisibilitySettings({
+    showCode: true,
+    showStdout: true,
+    showStderr: true,
+    showResult: true,
+    showError: true,
+    showStatusDot: true,
+  }, false);
+});
+
+describe('getEffectiveVisibility – 4-level priority cascade', () => {
+  test('Priority 1: cell showAll overrides cell metadata', () => {
+    // Set showAll (no other state changes — avoids SolidJS store proxy interactions)
+    setCellShowAll('cell-1', true);
+
+    // Even though metadata says hide code and stdout, showAll returns all-true defaults
+    const vis = getEffectiveVisibility('cell-1', { showCode: false, showStdout: false });
+    expect(vis.showCode).toBe(true);
+    expect(vis.showStdout).toBe(true);
+  });
+
+  test('Priority 2: user override ignores cell metadata', () => {
+    setVisibilitySettings({ showStdout: false }, true);
+    const metadata: CellCodeVisibility = { showStdout: true };
+
+    const vis = getEffectiveVisibility('cell-2', metadata);
+    expect(vis.showStdout).toBe(false);
+  });
+
+  test('Priority 3: cell metadata merges with global when no user override', () => {
+    const metadata: CellCodeVisibility = { showCode: false };
+
+    const vis = getEffectiveVisibility('cell-3', metadata);
+    expect(vis.showCode).toBe(false);
+    expect(vis.showStdout).toBe(true);
+    expect(vis.showLineNumbers).toBe(codeVisibility.showLineNumbers);
+  });
+
+  test('Priority 4: no metadata, no overrides — returns global settings', () => {
+    setVisibilitySettings({ showResult: false, showError: false }, false);
+
+    const vis = getEffectiveVisibility('cell-4');
+    expect(vis.showResult).toBe(false);
+    expect(vis.showError).toBe(false);
+    expect(vis.showCode).toBe(true);
+  });
+});

--- a/src/__tests__/unit/color-conversions.test.ts
+++ b/src/__tests__/unit/color-conversions.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'vitest';
+import { hexToHSL, hslToHex, generateColorPalette, withAlpha } from '../../lib/chart-theme';
+
+describe('hexToHSL', () => {
+  test('known values: pure red, green, blue, white, black', () => {
+    const red = hexToHSL('#ff0000');
+    expect(red.h).toBeCloseTo(0, 0);
+    expect(red.s).toBeCloseTo(100, 0);
+    expect(red.l).toBeCloseTo(50, 0);
+
+    const green = hexToHSL('#00ff00');
+    expect(green.h).toBeCloseTo(120, 0);
+    expect(green.s).toBeCloseTo(100, 0);
+    expect(green.l).toBeCloseTo(50, 0);
+
+    const blue = hexToHSL('#0000ff');
+    expect(blue.h).toBeCloseTo(240, 0);
+    expect(blue.s).toBeCloseTo(100, 0);
+    expect(blue.l).toBeCloseTo(50, 0);
+
+    const white = hexToHSL('#ffffff');
+    expect(white.s).toBeCloseTo(0);
+    expect(white.l).toBeCloseTo(100);
+
+    const black = hexToHSL('#000000');
+    expect(black.s).toBeCloseTo(0);
+    expect(black.l).toBeCloseTo(0);
+  });
+
+  test('accepts hex without # prefix', () => {
+    const hsl = hexToHSL('ff0000');
+    expect(hsl.h).toBeCloseTo(0, 0);
+    expect(hsl.l).toBeCloseTo(50, 0);
+  });
+});
+
+describe('hslToHex', () => {
+  test('known values produce correct hex', () => {
+    expect(hslToHex({ h: 0, s: 100, l: 50 })).toBe('#ff0000');
+    expect(hslToHex({ h: 120, s: 100, l: 50 })).toBe('#00ff00');
+    expect(hslToHex({ h: 240, s: 100, l: 50 })).toBe('#0000ff');
+  });
+
+  test('hexToHSL → hslToHex roundtrip is stable', () => {
+    const inputs = ['#f38ba8', '#89b4fa', '#1e1e2e', '#cdd6f4'];
+    for (const hex of inputs) {
+      const hsl = hexToHSL(hex);
+      const back = hslToHex(hsl);
+      expect(back).toBe(hex);
+    }
+  });
+});
+
+describe('generateColorPalette', () => {
+  test('returns requested count with base color first', () => {
+    const palette = generateColorPalette('#ff0000', 5);
+    expect(palette).toHaveLength(5);
+    expect(palette[0]).toBe('#ff0000');
+  });
+
+  test('all generated colors are unique', () => {
+    const palette = generateColorPalette('#89b4fa', 8);
+    const unique = new Set(palette);
+    expect(unique.size).toBe(8);
+  });
+});
+
+describe('withAlpha', () => {
+  test('appends correct hex alpha values', () => {
+    expect(withAlpha('#ff0000', 1)).toBe('#ff0000ff');
+    expect(withAlpha('#ff0000', 0)).toBe('#ff000000');
+    expect(withAlpha('#ff0000', 0.5)).toBe('#ff000080');
+  });
+});

--- a/src/__tests__/unit/color-utils.test.ts
+++ b/src/__tests__/unit/color-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'vitest';
+import {
+  resolveColor,
+  resolveBorder,
+  isCustomColor,
+  COLOR_PRESETS,
+} from '../../components/ui-renderer/colorUtils';
+
+describe('isCustomColor', () => {
+  test('preset names return false', () => {
+    for (const preset of COLOR_PRESETS) {
+      expect(isCustomColor(preset)).toBe(false);
+    }
+  });
+
+  test('hex, rgb, hsl, and named CSS colors return true', () => {
+    expect(isCustomColor('#ff0000')).toBe(true);
+    expect(isCustomColor('#f00')).toBe(true);
+    expect(isCustomColor('rgb(255, 0, 0)')).toBe(true);
+    expect(isCustomColor('rgba(255, 0, 0, 0.5)')).toBe(true);
+    expect(isCustomColor('hsl(0, 100%, 50%)')).toBe(true);
+    expect(isCustomColor('red')).toBe(true);
+    expect(isCustomColor('transparent')).toBe(true);
+  });
+
+  test('unknown non-CSS strings return false', () => {
+    expect(isCustomColor('banana')).toBe(false);
+    expect(isCustomColor('foobar')).toBe(false);
+  });
+});
+
+describe('resolveColor', () => {
+  test('preset name wraps in CSS variable', () => {
+    expect(resolveColor('primary')).toBe('var(--primary)');
+    expect(resolveColor('accent')).toBe('var(--accent)');
+  });
+
+  test('neutral maps to var(--foreground)', () => {
+    expect(resolveColor('neutral')).toBe('var(--foreground)');
+  });
+
+  test('custom hex passes through unchanged', () => {
+    expect(resolveColor('#ff0000')).toBe('#ff0000');
+    expect(resolveColor('rgb(0,0,0)')).toBe('rgb(0,0,0)');
+  });
+
+  test('null/undefined uses default preset', () => {
+    expect(resolveColor(null)).toBe('var(--primary)');
+    expect(resolveColor(undefined)).toBe('var(--primary)');
+    expect(resolveColor(null, 'accent')).toBe('var(--accent)');
+  });
+});
+
+describe('resolveBorder', () => {
+  test('false and "none" return border: none', () => {
+    expect(resolveBorder(false)).toEqual({ border: 'none' });
+    expect(resolveBorder('none')).toEqual({ border: 'none' });
+  });
+
+  test('true, null, undefined return empty object (use default)', () => {
+    expect(resolveBorder(true)).toEqual({});
+    expect(resolveBorder(null)).toEqual({});
+    expect(resolveBorder(undefined)).toEqual({});
+  });
+
+  test('preset string becomes 2px solid with CSS var', () => {
+    expect(resolveBorder('primary')).toEqual({ border: '2px solid var(--primary)' });
+    expect(resolveBorder('neutral')).toEqual({ border: '2px solid var(--foreground)' });
+  });
+
+  test('custom color becomes 2px solid border', () => {
+    expect(resolveBorder('#ff0000')).toEqual({ border: '2px solid #ff0000' });
+  });
+
+  test('full CSS border value passes through', () => {
+    expect(resolveBorder('3px dashed red')).toEqual({ border: '3px dashed red' });
+  });
+});

--- a/src/__tests__/unit/dag.test.ts
+++ b/src/__tests__/unit/dag.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from 'vitest';
+import { actions } from '../../lib/store';
+import type { CellData } from '../../lib/store';
+
+// Helper: load a set of code cells with known IDs and set their dependencies
+function setupCells(
+  defs: Array<{ id: string; definitions: string[]; references: string[] }>
+) {
+  const cells: CellData[] = defs.map(d => ({
+    id: d.id,
+    type: 'code' as const,
+    content: '',
+  }));
+  actions.loadNotebook(cells, 'test.ipynb');
+  for (const d of defs) {
+    actions.setCellDependencies(d.id, d.definitions, d.references);
+  }
+}
+
+describe('getDependencyGraph', () => {
+  test('builds edges from defining cell to referencing cell', () => {
+    setupCells([
+      { id: 'A', definitions: ['x'], references: [] },
+      { id: 'B', definitions: ['y'], references: ['x'] },
+      { id: 'C', definitions: [], references: ['y'] },
+    ]);
+
+    const graph = actions.getDependencyGraph();
+    expect(graph.get('A')!.has('B')).toBe(true);
+    expect(graph.get('B')!.has('C')).toBe(true);
+    expect(graph.get('C')!.size).toBe(0);
+  });
+
+  test('self-references are ignored', () => {
+    setupCells([
+      { id: 'A', definitions: ['x'], references: ['x'] },
+    ]);
+    const graph = actions.getDependencyGraph();
+    expect(graph.get('A')!.size).toBe(0);
+  });
+});
+
+describe('getDownstreamCells', () => {
+  test('linear chain returns cells in topological order', () => {
+    setupCells([
+      { id: 'A', definitions: ['x'], references: [] },
+      { id: 'B', definitions: ['y'], references: ['x'] },
+      { id: 'C', definitions: [], references: ['y'] },
+    ]);
+
+    const downstream = actions.getDownstreamCells('A');
+    expect(downstream).toEqual(['B', 'C']);
+  });
+
+  test('diamond dependency returns unique cells in valid topological order', () => {
+    //   A
+    //  / \
+    // B   C
+    //  \ /
+    //   D
+    setupCells([
+      { id: 'A', definitions: ['x'], references: [] },
+      { id: 'B', definitions: ['y'], references: ['x'] },
+      { id: 'C', definitions: ['z'], references: ['x'] },
+      { id: 'D', definitions: [], references: ['y', 'z'] },
+    ]);
+
+    const downstream = actions.getDownstreamCells('A');
+    expect(downstream).toHaveLength(3);
+    // D must come after both B and C
+    expect(downstream.indexOf('D')).toBeGreaterThan(downstream.indexOf('B'));
+    expect(downstream.indexOf('D')).toBeGreaterThan(downstream.indexOf('C'));
+  });
+
+  test('isolated cell has no downstream', () => {
+    setupCells([
+      { id: 'A', definitions: ['x'], references: [] },
+      { id: 'B', definitions: ['y'], references: [] },
+    ]);
+
+    expect(actions.getDownstreamCells('A')).toEqual([]);
+  });
+
+  test('cycle falls back to BFS order without crashing', () => {
+    setupCells([
+      { id: 'A', definitions: ['x'], references: ['z'] },
+      { id: 'B', definitions: ['y'], references: ['x'] },
+      { id: 'C', definitions: ['z'], references: ['y'] },
+    ]);
+
+    // A→B→C→A forms a cycle. getDownstreamCells should not hang
+    const downstream = actions.getDownstreamCells('A');
+    expect(downstream).toContain('B');
+    expect(downstream).toContain('C');
+  });
+});

--- a/src/__tests__/unit/header-level.test.ts
+++ b/src/__tests__/unit/header-level.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest';
+import { getLastHeaderLevel } from '../../components/CellWrapper';
+
+describe('getLastHeaderLevel', () => {
+  test('returns 0 when no headers present', () => {
+    expect(getLastHeaderLevel('just text\nno headers here')).toBe(0);
+    expect(getLastHeaderLevel('')).toBe(0);
+  });
+
+  test('returns last header level, capped at 4', () => {
+    expect(getLastHeaderLevel('# H1\n## H2\n### H3')).toBe(3);
+    expect(getLastHeaderLevel('## H2\n# H1')).toBe(1);
+    // H5 and H6 are capped at 4
+    expect(getLastHeaderLevel('##### H5')).toBe(4);
+    expect(getLastHeaderLevel('###### H6')).toBe(4);
+    expect(getLastHeaderLevel('#### H4')).toBe(4);
+  });
+
+  test('ignores lines where # is not at the start or lacks trailing space', () => {
+    // Not at start of line
+    expect(getLastHeaderLevel('text ## not a header')).toBe(0);
+    // No space after # — not a valid ATX header
+    expect(getLastHeaderLevel('#nospace')).toBe(0);
+    // Mix: one valid, one invalid
+    expect(getLastHeaderLevel('## Valid\n#invalid')).toBe(2);
+  });
+});

--- a/src/__tests__/unit/output-parse.test.ts
+++ b/src/__tests__/unit/output-parse.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'vitest';
+import {
+  parseStdoutWithUI,
+  parseMarkdownWithUI,
+  MARKER_UI_START,
+  MARKER_UI_END,
+  MARKER_MD_STYLED_START,
+  MARKER_MD_STYLED_END,
+  MARKER_MD_PLAIN_START,
+  MARKER_MD_PLAIN_END,
+} from '../../components/Output';
+
+const ui = (json: string) => `${MARKER_UI_START}${json}${MARKER_UI_END}`;
+const mdStyled = (text: string) => `${MARKER_MD_STYLED_START}${text}${MARKER_MD_STYLED_END}`;
+const mdPlain = (text: string) => `${MARKER_MD_PLAIN_START}${text}${MARKER_MD_PLAIN_END}`;
+
+describe('parseStdoutWithUI', () => {
+  test('empty input returns empty array', () => {
+    expect(parseStdoutWithUI([])).toEqual([]);
+    expect(parseStdoutWithUI([''])).toEqual([]);
+  });
+
+  test('plain text returns single text segment', () => {
+    const result = parseStdoutWithUI(['hello world']);
+    expect(result).toEqual([{ type: 'text', content: 'hello world' }]);
+  });
+
+  test('interleaved text, UI, and markdown segments', () => {
+    const json = JSON.stringify({ id: 'btn1', type: 'button', props: { label: 'OK' } });
+    const input = `before${ui(json)}middle${mdStyled('# Title')}after`;
+    const result = parseStdoutWithUI([input]);
+
+    expect(result).toHaveLength(5);
+    expect(result[0]).toEqual({ type: 'text', content: 'before' });
+    expect(result[1]).toEqual({ type: 'ui', data: { id: 'btn1', type: 'button', props: { label: 'OK' } } });
+    expect(result[2]).toEqual({ type: 'text', content: 'middle' });
+    expect(result[3]).toEqual({ type: 'markdown', content: '# Title', styled: true });
+    expect(result[4]).toEqual({ type: 'text', content: 'after' });
+  });
+
+  test('malformed JSON in UI marker falls back to text segment', () => {
+    const input = `${ui('{not json}')}`;
+    const result = parseStdoutWithUI([input]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: 'text', content: '{not json}' });
+  });
+
+  test('nested UI inside markdown is skipped at top level', () => {
+    const innerUI = ui(JSON.stringify({ id: 'x', type: 'btn', props: {} }));
+    const input = `${mdPlain(`text ${innerUI} more`)}`;
+    const result = parseStdoutWithUI([input]);
+    // Only one markdown segment — nested UI is NOT extracted as a separate top-level segment
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('markdown');
+  });
+
+  test('plain markdown segment has styled=false', () => {
+    const result = parseStdoutWithUI([mdPlain('hello')]);
+    expect(result[0]).toEqual({ type: 'markdown', content: 'hello', styled: false });
+  });
+
+  test('handles split across multiple stdout chunks', () => {
+    // The markers might be split across separate print() calls
+    const json = JSON.stringify({ id: 'a', type: 'b', props: {} });
+    const full = `pre${ui(json)}post`;
+    const mid = Math.floor(full.length / 2);
+    const result = parseStdoutWithUI([full.slice(0, mid), full.slice(mid)]);
+    expect(result.some(s => s.type === 'ui')).toBe(true);
+    expect(result[0]).toEqual({ type: 'text', content: 'pre' });
+  });
+});
+
+describe('parseMarkdownWithUI', () => {
+  test('text with embedded UI elements', () => {
+    const json = JSON.stringify({ id: 'slider1', type: 'slider', props: { min: 0 } });
+    const content = `Hello ${ui(json)} world`;
+    const result = parseMarkdownWithUI(content);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ type: 'text', content: 'Hello ' });
+    expect(result[1]).toEqual({ type: 'ui', data: { id: 'slider1', type: 'slider', props: { min: 0 } } });
+    expect(result[2]).toEqual({ type: 'text', content: ' world' });
+  });
+
+  test('invalid JSON preserved as raw text including markers', () => {
+    const raw = ui('not-json');
+    const result = parseMarkdownWithUI(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('text');
+    // The raw marker text is preserved
+    expect((result[0] as { type: "text"; content: string }).content).toBe(raw);
+  });
+
+  test('no markers returns single text segment', () => {
+    const result = parseMarkdownWithUI('just text');
+    expect(result).toEqual([{ type: 'text', content: 'just text' }]);
+  });
+});

--- a/src/__tests__/unit/store-escape.test.ts
+++ b/src/__tests__/unit/store-escape.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'vitest';
+import { escapeContent, unescapeContent, parseUpdateEntry } from '../../lib/store';
+
+describe('escapeContent / unescapeContent', () => {
+  test('roundtrip preserves pipes, backslashes, and their combinations', () => {
+    const cases = [
+      'hello world',
+      'pipe|in|content',
+      'back\\slash',
+      'combo\\|mixed\\\\|end',
+      '',
+    ];
+    for (const input of cases) {
+      expect(unescapeContent(escapeContent(input))).toBe(input);
+    }
+  });
+
+  test('escapeContent encodes pipes and backslashes', () => {
+    expect(escapeContent('a|b')).toBe('a\\|b');
+    expect(escapeContent('a\\b')).toBe('a\\\\b');
+    expect(escapeContent('a\\|b')).toBe('a\\\\\\|b');
+  });
+
+  test('unescapeContent decodes in correct order (pipes before backslashes)', () => {
+    expect(unescapeContent('a\\|b')).toBe('a|b');
+    expect(unescapeContent('a\\\\b')).toBe('a\\b');
+  });
+});
+
+describe('parseUpdateEntry', () => {
+  test('extracts id, oldContent, newContent from normal entry', () => {
+    const old = escapeContent('hello');
+    const now = escapeContent('world');
+    const entry = `u|cell-1|${old}|${now}`;
+    const result = parseUpdateEntry(entry);
+    expect(result).toEqual({ id: 'cell-1', oldContent: 'hello', newContent: 'world' });
+  });
+
+  test('handles escaped pipes inside content fields', () => {
+    const old = escapeContent('a|b');
+    const now = escapeContent('c|d');
+    const entry = `u|cell-2|${old}|${now}`;
+    const result = parseUpdateEntry(entry);
+    expect(result).toEqual({ id: 'cell-2', oldContent: 'a|b', newContent: 'c|d' });
+  });
+
+  test('handles double-backslash before separator pipe', () => {
+    // Content ends with a literal backslash: "end\\"
+    // Escaped: "end\\\\" — the separator pipe follows an even number of backslashes
+    const old = escapeContent('end\\');
+    const now = escapeContent('start');
+    const entry = `u|cell-3|${old}|${now}`;
+    const result = parseUpdateEntry(entry);
+    expect(result).toEqual({ id: 'cell-3', oldContent: 'end\\', newContent: 'start' });
+  });
+
+  test('returns null for malformed entries', () => {
+    expect(parseUpdateEntry('u')).toBeNull();
+    expect(parseUpdateEntry('u|id')).toBeNull();
+    // No unescaped separator between old and new content
+    expect(parseUpdateEntry('u|id|only-one-field')).toBeNull();
+  });
+});

--- a/src/components/CellWrapper.tsx
+++ b/src/components/CellWrapper.tsx
@@ -5,6 +5,7 @@ import { GripVertical, Trash2, Play, Square, Edit2, Check, Timer, Eye, EyeOff, A
 import clsx from "clsx";
 import { notebookStore, APP_ENABLE_CELL_DND, APP_QUIET_MODE } from "../lib/store";
 import { currentTheme } from "../lib/theme";
+import { TESTID } from "../lib/testids";
 
 // Reactive store for cell exit levels - tracks each cell's exit level
 // Each cell writes its exit level here, next cell reads via prevCellId prop
@@ -136,6 +137,8 @@ const CellWrapper: Component<CellWrapperProps> = (props) => {
   return (
     <div
       id={`cell-${props.id}`}
+      data-testid={TESTID.cell}
+      data-cell-id={props.id}
       ref={(el) => { sortable.ref(el); elementRef = el; }}
       {...(APP_ENABLE_CELL_DND ? sortable.dragActivators : {})}
       onKeyDown={undefined}

--- a/src/components/Notebook.tsx
+++ b/src/components/Notebook.tsx
@@ -12,6 +12,7 @@ import Dropdown, { DropdownItem, DropdownDivider } from "./ui/Dropdown";
 import { sessionManager } from "../lib/session";
 import { codeVisibility, setVisibilitySettings, resetUserOverride, getSessionState, restoreSessionState, setOnCellOverrideChange, applyDocumentSettings, shouldLoadMetadataSettings, shouldAutoRun, shouldAutoRunOnRefresh, type CodeVisibilitySettings } from "../lib/codeVisibility";
 import { currentTheme, updateTheme, saveThemeAppWide, loadAppTheme } from "../lib/theme";
+import { TESTID } from "../lib/testids";
 
 const PerformanceMonitor = lazy(() => import("./PerformanceMonitor"));
 const CodeVisibilityDialog = lazy(() => import("./CodeVisibilityDialog"));
@@ -1670,7 +1671,7 @@ const Notebook: Component = () => {
                    return i + 1;
                  })();
                  actions.addCell("code", idx);
-               }} class="btn-toolbar flex items-center gap-1" title="Add Code Cell">
+               }} class="btn-toolbar flex items-center gap-1" title="Add Code Cell" data-testid={TESTID.addCodeCell}>
                  <Plus size={20} /> <Code size={20} />
                </button>
                <button onClick={() => {
@@ -1682,7 +1683,7 @@ const Notebook: Component = () => {
                    return i + 1;
                  })();
                  actions.addCell("markdown", idx);
-               }} class="btn-toolbar flex items-center gap-1" title="Add Markdown Cell">
+               }} class="btn-toolbar flex items-center gap-1" title="Add Markdown Cell" data-testid={TESTID.addMarkdownCell}>
                  <Plus size={20} /> <FileText size={20} />
                </button>
                
@@ -1919,7 +1920,10 @@ const Notebook: Component = () => {
            </div>
   
            <div class="flex items-center gap-2 max-xs:flex-1 max-xs:justify-center">
-             <div class={`text-xs font-mono py-1 rounded-sm flex items-center gap-2 ${
+             <div
+               data-testid={TESTID.kernelStatus}
+               data-status={kernel.status}
+               class={`text-xs font-mono py-1 rounded-sm flex items-center gap-2 ${
                  kernel.status === "ready" ? "text-success" :
                  (kernel.status === "loading" || kernel.status === "running") ? "text-warning" :
                  "text-error"

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -5,6 +5,7 @@ import { marked } from "marked";
 import markedKatex from "marked-katex-extension";
 import katex from "katex";
 import DOMPurify from "dompurify";
+import { TESTID } from "../lib/testids";
 
 interface OutputProps {
   outputs: CellData["outputs"];
@@ -20,12 +21,12 @@ interface StdoutOutputProps extends OutputProps {
 
 // Control character markers matching Python's pynote_ui
 // Self-closing pattern: \x02TYPE\x02content\x02/TYPE\x02
-const MARKER_UI_START = "\x02PYNOTE_UI\x02";
-const MARKER_UI_END = "\x02/PYNOTE_UI\x02";
-const MARKER_MD_STYLED_START = "\x02PYNOTE_MD_STYLED\x02";
-const MARKER_MD_STYLED_END = "\x02/PYNOTE_MD_STYLED\x02";
-const MARKER_MD_PLAIN_START = "\x02PYNOTE_MD_PLAIN\x02";
-const MARKER_MD_PLAIN_END = "\x02/PYNOTE_MD_PLAIN\x02";
+export const MARKER_UI_START = "\x02PYNOTE_UI\x02";
+export const MARKER_UI_END = "\x02/PYNOTE_UI\x02";
+export const MARKER_MD_STYLED_START = "\x02PYNOTE_MD_STYLED\x02";
+export const MARKER_MD_STYLED_END = "\x02/PYNOTE_MD_STYLED\x02";
+export const MARKER_MD_PLAIN_START = "\x02PYNOTE_MD_PLAIN\x02";
+export const MARKER_MD_PLAIN_END = "\x02/PYNOTE_MD_PLAIN\x02";
 
 // Configure marked for markdown rendering (same as MarkdownCell)
 const displayMath = {
@@ -58,17 +59,17 @@ const purifyOptions = {
 };
 
 // Parse stdout content for interleaved text, UI elements, and markdown
-type OutputSegment =
+export type OutputSegment =
   | { type: "text"; content: string }
   | { type: "ui"; data: { id: string; type: string; props: any } }
   | { type: "markdown"; content: string; styled: boolean };
 
 // Sub-segment within markdown (text or UI)
-type MarkdownSubSegment =
+export type MarkdownSubSegment =
   | { type: "text"; content: string }
   | { type: "ui"; data: { id: string; type: string; props: any } };
 
-function parseStdoutWithUI(stdout: string[]): OutputSegment[] {
+export function parseStdoutWithUI(stdout: string[]): OutputSegment[] {
   const combined = stdout.join("");
   if (!combined) return [];
 
@@ -194,7 +195,7 @@ function parseStdoutWithUI(stdout: string[]): OutputSegment[] {
 }
 
 // Parse markdown content for embedded UI elements
-function parseMarkdownWithUI(content: string): MarkdownSubSegment[] {
+export function parseMarkdownWithUI(content: string): MarkdownSubSegment[] {
   const segments: MarkdownSubSegment[] = [];
   const uiPattern = new RegExp(
     `${escapeRegex(MARKER_UI_START)}(.+?)${escapeRegex(MARKER_UI_END)}`,
@@ -512,7 +513,7 @@ export const OutputStdoutUI: Component<StdoutOutputProps> = (props) => {
 
   return (
     <Show when={hasContent()}>
-      <div class={containerClass()}>
+      <div class={containerClass()} data-testid={TESTID.cellOutput}>
         <Show when={segments().length > 0}>
           {/* Render all segments in one container for inline flow */}
           <div class="text-secondary whitespace-pre-wrap min-w-0">

--- a/src/components/ui-renderer/colorUtils.ts
+++ b/src/components/ui-renderer/colorUtils.ts
@@ -23,7 +23,7 @@
 /**
  * List of valid theme color presets
  */
-const COLOR_PRESETS = [
+export const COLOR_PRESETS = [
     "neutral",
     "primary",
     "secondary",
@@ -39,7 +39,7 @@ const COLOR_PRESETS = [
  * @param color - Color string to check
  * @returns true if it's a custom CSS color
  */
-function isCustomColor(color: string): boolean {
+export function isCustomColor(color: string): boolean {
     // Check if it's one of our presets
     if (COLOR_PRESETS.includes(color as any)) {
         return false;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -146,11 +146,11 @@ let batchedEntries: HistoryEntry[] = [];
 
 // --- History Storage Utilities ---
 // Robust string escaping for pipe-delimited format
-const escapeContent = (s: string) => s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
-const unescapeContent = (s: string) => s.replace(/\\\|/g, '|').replace(/\\\\/g, '\\');
+export const escapeContent = (s: string) => s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+export const unescapeContent = (s: string) => s.replace(/\\\|/g, '|').replace(/\\\\/g, '\\');
 
 // Helper to parse "u|id|old|new" which has two escaped distinct content blocks
-const parseUpdateEntry = (entry: string): { id: string, oldContent: string, newContent: string } | null => {
+export const parseUpdateEntry = (entry: string): { id: string, oldContent: string, newContent: string } | null => {
   // skip "u|" (2 chars)
   const firstPipe = entry.indexOf('|');
   const secondPipe = entry.indexOf('|', firstPipe + 1);

--- a/src/lib/testids.ts
+++ b/src/lib/testids.ts
@@ -1,0 +1,21 @@
+// Single source of truth for stable `data-testid` hooks used by end-to-end
+// tests. Both the application components and the Playwright suite import from
+// here so that renaming a hook is a single, compile-checked edit instead of a
+// silent string mismatch.
+//
+// Guidelines:
+// - Only add a hook when a test needs to target an element that has no other
+//   stable, semantic selector (role, label, text). Prefer Playwright's
+//   role/text locators where they are reliable; reach for a testid for
+//   structural containers and status elements.
+// - Keep values kebab-cased and human-readable.
+export const TESTID = {
+  appRoot: "app-root",
+  kernelStatus: "kernel-status",
+  addCodeCell: "add-code-cell",
+  addMarkdownCell: "add-markdown-cell",
+  cell: "cell",
+  cellOutput: "cell-output",
+} as const;
+
+export type TestId = (typeof TESTID)[keyof typeof TESTID];


### PR DESCRIPTION
Adds vitest tests covering escape/parse, DAG, execution queue, kernel routing, undo/redo, chart theming, output parsing, color utils, code visibility, and header levels.