### PR TITLE
Adds an internal Pyodide filesystem management system and ship the new Files and Data panel and dialog UI experience

### DIFF
--- a/docs/system-architecture/files-data-panel-architecture.md
+++ b/docs/system-architecture/files-data-panel-architecture.md
@@ -1,0 +1,188 @@
+# Files and Data Persistence Architecture
+
+## Why this document exists
+
+The Files and Data panel introduced a second persistence path in the app. This is intentional and architecturally important. This document explains:
+
+- how notebook session persistence differs from filesystem persistence,
+- why both are kept separate,
+- what "Persistent" vs fallback states mean in practice,
+- and what guarantees users should expect.
+
+## Two persistence systems, one browser
+
+PyNote now persists two different domains:
+
+1. Notebook session state (document-level)
+- Lives in app-level session storage flow.
+- Shape is structured notebook JSON: cells, history, metadata, visibility settings, theme/session options.
+- Managed from main-thread app logic.
+
+2. Files and Data filesystem state (runtime file tree)
+- Lives in Pyodide worker filesystem under `/workspace`.
+- Shape is hierarchical files and directories, including binary payloads.
+- Managed from worker filesystem logic.
+
+Both persist to browser storage, but through different engines and data models.
+
+## New Files and Data system (implemented architecture)
+
+Before comparing persistence models, here is the concrete Files and Data system that was added.
+
+### Components
+
+1. Files and Data UI (`FileWorkspacePanel`)
+- Renders file browser UX in two modes: side panel and dialog.
+- Sends typed filesystem commands through the kernel bridge.
+
+2. Kernel bridge (`kernel.filesystem(...)`)
+- Main-thread API that forwards filesystem requests to the worker.
+- Preserves a clean UI-to-worker contract.
+
+3. Worker filesystem service (`filesystem` message handler)
+- Validates and normalizes paths.
+- Enforces root sandboxing to `/workspace`.
+- Executes file operations (`list`, `upload`, `mkdir`, `rename`, `move`, `copy`, `delete`, `read_text`, `download`).
+
+4. Persistence adapter (IDBFS sync layer)
+- Mounts IDBFS at `/workspace` when available.
+- Hydrates runtime FS on startup.
+- Flushes mutations back to browser storage after writes.
+
+### End-to-end operation path
+
+1. User action in panel (example: upload file).
+2. UI calls `kernel.filesystem({ op: "upload", ... })`.
+3. Worker receives `filesystem` request and resolves target path under `/workspace`.
+4. Worker executes filesystem mutation in Pyodide FS.
+5. If persistence is enabled, worker flushes via sync to browser storage.
+6. Worker returns operation result.
+7. UI refreshes listing, then reads and renders persistence status from `list`.
+
+### Scope and guarantees of this system
+
+- Files and directories are sandboxed to `/workspace`.
+- Persistence behavior is runtime-aware (persistent mode when IDBFS is mounted, fallback mode otherwise).
+- The system is intentionally owned by the worker/runtime layer, not the notebook document/session layer.
+
+## Why not store Files and Data in the notebook session store?
+
+Keeping filesystem persistence separate is a deliberate architecture choice.
+
+### Data model mismatch
+
+Notebook session persistence is optimized for JSON document state. Filesystem persistence needs file operations and tree semantics:
+
+- rename / move / copy / recursive delete
+- binary file payloads
+- directory traversal and metadata
+
+Encoding filesystem state into notebook session JSON would add heavy transforms and brittle logic.
+
+### Runtime ownership boundary
+
+File operations execute inside the Pyodide worker. Persisting at that layer keeps ownership local to where the filesystem actually exists.
+
+### Performance and churn
+
+Notebook autosave is frequent and lightweight. Filesystem payloads can be large and binary-heavy. Merging them would bloat session snapshots and increase write amplification.
+
+### Failure isolation
+
+Notebook session save and filesystem sync can fail independently. Separation reduces blast radius and simplifies debugging.
+
+## Filesystem persistence flow
+
+### 1) Worker startup
+
+- Create/ensure root `/workspace`.
+- Attempt to mount IDBFS at `/workspace`.
+- If mount succeeds: mark persistence enabled, then hydrate runtime FS from browser storage.
+- If mount fails: continue with ephemeral in-memory FS.
+
+### 2) Runtime operations
+
+The worker handles filesystem requests:
+
+- `list`, `mkdir`, `upload`, `delete`, `rename`, `move`, `copy`, `read_text`, `download`
+
+Mutating operations call sync flush so changes are committed to backing storage when persistence is enabled.
+
+### 3) UI status
+
+`list` returns `persistent: boolean`.
+The panel renders status from this flag.
+
+## State meanings in Files and Data
+
+### Persistent
+
+- IDBFS mount succeeded.
+- `/workspace` is backed by browser storage.
+- Files survive refresh/reload and worker/kernel recreation (unless browser storage is cleared/evicted).
+
+### Session memory (fallback label)
+
+- IDBFS mount unavailable.
+- Files exist only in runtime memory.
+- Files are lost when runtime is recreated.
+
+Note: in app terminology, "session" may survive refresh/reload for notebook state. The fallback label here refers specifically to filesystem runtime behavior, not notebook session semantics.
+
+## Architectural comparison
+
+| Concern | Notebook session persistence | Files and Data persistence |
+|---|---|---|
+| Owner | Main thread app/session layer | Pyodide worker filesystem layer |
+| Data shape | Notebook JSON/document state | File tree + binary content |
+| Operations | Snapshot save/restore | Filesystem ops + sync flush |
+| Typical payload | Small/medium structured data | Potentially large binary datasets |
+| Best-fit engine | App session store | IDBFS via Pyodide FS |
+
+## Practical implications for users
+
+- Notebook content and Files and Data are persisted independently.
+- A successful notebook autosave does not imply filesystem sync success, and vice versa.
+- Persistent filesystem mode is expected to retain uploads across reloads/restarts.
+- Browser storage lifecycle still applies (clear site data/private mode/quota eviction can remove persisted data).
+
+## Tradeoff and rationale summary
+
+Yes, this introduces a second persistence system. The tradeoff is accepted because it avoids:
+
+- complex filtering/translation between incompatible data structures,
+- inefficient binary-in-JSON session payloads,
+- and reimplementation of filesystem semantics in session code.
+
+The result is cleaner boundaries, better operational correctness, and lower maintenance risk.
+
+## Code references
+
+Use these references to validate each architectural claim in implementation code.
+
+### Filesystem persistence in worker
+
+- Root and persistence state: [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L5-L6)
+- Path normalization and `/workspace` sandboxing: [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L23-L31)
+- IDBFS mount and startup hydration (`syncfs(true)`): [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L62-L76)
+- Sync helper and flush behavior (`syncfs`): [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L52-L60)
+- Filesystem operations handler (`list`, `mkdir`, `upload`, `delete`, `rename`, `move`, `copy`, `read_text`, `download`): [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L155-L274)
+- `list` returns persistence flag: [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L163-L167)
+- Worker init calls filesystem setup: [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L2546-L2547)
+- Worker filesystem message route: [src/lib/pyodide.worker.ts](../../src/lib/pyodide.worker.ts#L2667-L2682)
+
+### Kernel bridge
+
+- Typed filesystem request contract: [src/lib/pyodide.ts](../../src/lib/pyodide.ts#L17-L26)
+- `kernel.filesystem(...)` request/response bridge: [src/lib/pyodide.ts](../../src/lib/pyodide.ts#L212-L231)
+
+### Files and Data UI
+
+- Panel calls through kernel bridge: [src/components/FileWorkspacePanel.tsx](../../src/components/FileWorkspacePanel.tsx#L142-L274)
+- UI reads persistence from `list` and stores state: [src/components/FileWorkspacePanel.tsx](../../src/components/FileWorkspacePanel.tsx#L142-L148)
+- Status rendering labels (`Persistent` / `Session memory`): [src/components/FileWorkspacePanel.tsx](../../src/components/FileWorkspacePanel.tsx#L667-L675)
+
+### Notebook session persistence (separate system)
+
+- Autosave session snapshot path: [src/components/Notebook.tsx](../../src/components/Notebook.tsx#L808-L845)
+- Session restore path: [src/components/Notebook.tsx](../../src/components/Notebook.tsx#L861-L910)

--- a/e2e/pages/NotebookPage.ts
+++ b/e2e/pages/NotebookPage.ts
@@ -41,9 +41,33 @@ export class NotebookPage {
     return this.page.getByTestId(TESTID.cellOutput);
   }
 
+  get filesDialog(): Locator {
+    return this.page.getByTestId(TESTID.filesDialog);
+  }
+
+  get filesSidePanel(): Locator {
+    return this.page.getByTestId(TESTID.filesSidePanel);
+  }
+
   /** The CodeMirror editing surface inside the nth cell (0-based). */
   cellEditor(index: number): Locator {
     return this.cells.nth(index).locator(".cm-editor");
+  }
+
+  filesPanel(mode: "side" | "dialog"): Locator {
+    return this.page.locator(`[data-testid="${TESTID.filesPanelRoot}"][data-mode="${mode}"]`);
+  }
+
+  filesRow(mode: "side" | "dialog", name: string): Locator {
+    return this.filesPanel(mode).locator(`[data-testid="${TESTID.filesPanelRow}"][data-entry-name="${name}"]`).first();
+  }
+
+  filesBreadcrumb(mode: "side" | "dialog", path: string): Locator {
+    return this.filesPanel(mode).locator(`[data-testid="${TESTID.filesPanelBreadcrumb}"][data-path="${path}"]`).first();
+  }
+
+  uploadComponent(label: string): Locator {
+    return this.page.locator(`[data-testid="${TESTID.uploadComponent}"][data-label="${label}"]`).first();
   }
 
   // --- Navigation / lifecycle ------------------------------------------------
@@ -74,6 +98,17 @@ export class NotebookPage {
     await this.waitForKernelReady();
   }
 
+  async openFilesData(mode: "side" | "dialog"): Promise<void> {
+    await this.page.keyboard.press("Control+.");
+    if (mode === "dialog") {
+      await expect(this.filesDialog).toBeVisible();
+      await expect(this.filesPanel("dialog")).toBeVisible();
+      return;
+    }
+    await expect(this.filesSidePanel).toBeVisible();
+    await expect(this.filesPanel("side")).toBeVisible();
+  }
+
   // --- Actions ---------------------------------------------------------------
 
   async addCodeCell(): Promise<void> {
@@ -92,12 +127,60 @@ export class NotebookPage {
   async typeInCell(index: number, source: string): Promise<void> {
     const editor = this.cellEditor(index);
     await editor.click();
-    await this.page.keyboard.type(source);
+    await this.page.keyboard.insertText(source);
   }
 
   /** Run the focused cell and keep selection (Ctrl+Enter). */
   async runFocusedCell(): Promise<void> {
     await this.page.keyboard.press("Control+Enter");
+  }
+
+  /** Run a specific cell by clicking its toolbar button. */
+  async runCell(index: number): Promise<void> {
+    await this.cells.nth(index).getByRole("button", { name: "Run Cell" }).click();
+  }
+
+  async addAndRunCodeCell(source: string): Promise<number> {
+    await this.addCodeCell();
+    const index = (await this.cellCount()) - 1;
+    await this.typeInCell(index, source);
+    await this.page.keyboard.press("Escape");
+    await this.runCell(index);
+    return index;
+  }
+
+  async expectLastOutputToContain(text: string, timeout = 60_000): Promise<void> {
+    await expect(this.outputs.last()).toContainText(text, { timeout });
+  }
+
+  async expectCellOutputToContain(index: number, text: string, timeout = 60_000): Promise<void> {
+    await expect(this.cells.nth(index).getByTestId(TESTID.cellOutput)).toContainText(text, { timeout });
+  }
+
+  async expectAnyOutputToContain(text: string, timeout = 60_000): Promise<void> {
+    await expect(this.outputs.filter({ hasText: text }).first()).toBeVisible({ timeout });
+  }
+
+  async dragFileRowTo(mode: "side" | "dialog", sourceName: string, targetName: string): Promise<void> {
+    await this.filesRow(mode, sourceName).dragTo(this.filesRow(mode, targetName));
+  }
+
+  async dragFileRowToBreadcrumb(mode: "side" | "dialog", sourceName: string, targetPath: string): Promise<void> {
+    await this.filesRow(mode, sourceName).dragTo(this.filesBreadcrumb(mode, targetPath));
+  }
+
+  async refreshFilesData(mode: "side" | "dialog"): Promise<void> {
+    await this.filesPanel(mode).getByRole("button", { name: "Refresh" }).click();
+  }
+
+  async uploadFileViaComponent(
+    label: string,
+    file: { name: string; mimeType: string; buffer: Buffer },
+  ): Promise<void> {
+    const chooserPromise = this.page.waitForEvent("filechooser");
+    await this.uploadComponent(label).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles(file);
   }
 
   /**

--- a/e2e/tests/files-data-panel.spec.ts
+++ b/e2e/tests/files-data-panel.spec.ts
@@ -1,0 +1,417 @@
+import { test, expect } from "../support/fixtures";
+import { TESTID } from "../support/selectors";
+import type { Page, Dialog } from "@playwright/test";
+import type { NotebookPage } from "../pages/NotebookPage";
+
+type PanelMode = "side" | "dialog";
+
+const makeRunId = (): string => `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+
+const setupViewportAndOpen = async (
+  mode: PanelMode,
+  page: Page,
+  notebook: NotebookPage,
+): Promise<void> => {
+  if (mode === "side") {
+    await page.setViewportSize({ width: 1700, height: 1100 });
+  } else {
+    await page.setViewportSize({ width: 1280, height: 900 });
+  }
+
+  await notebook.open();
+};
+
+const runCellAndExpect = async (
+  page: Page,
+  notebook: NotebookPage,
+  code: string,
+  marker: string,
+): Promise<void> => {
+  if (await notebook.filesDialog.isVisible()) {
+    await page.keyboard.press("Control+.");
+    if (await notebook.filesDialog.isVisible()) {
+      await notebook.filesDialog.click({ position: { x: 8, y: 8 } });
+    }
+    await expect(notebook.filesDialog).toBeHidden();
+  }
+  await notebook.waitForKernelReady();
+  await notebook.addAndRunCodeCell(code);
+  await notebook.expectAnyOutputToContain(marker);
+};
+
+const cleanupRoot = async (
+  page: Page,
+  notebook: NotebookPage,
+  rootName: string,
+): Promise<void> => {
+  if (page.isClosed()) return;
+
+  try {
+    await runCellAndExpect(
+      page,
+      notebook,
+      [
+        "import shutil",
+        "from pathlib import Path",
+        `root = Path('/workspace') / '${rootName}'`,
+        "if root.exists():",
+        "    shutil.rmtree(root)",
+        "print('CLEANUP_OK')",
+      ].join("\n"),
+      "CLEANUP_OK",
+    );
+  } catch {
+    // Cleanup should never hide the original test failure signal.
+  }
+};
+
+test.describe("files and data panel", () => {
+  test("Upload component with dir writes to workspace and appears in Files & Data", async ({ notebook, page }) => {
+    const rootName = `e2e-upload-dir-${makeRunId()}`;
+    const uploadLabel = `Upload target ${rootName}`;
+    const fileName = "payload.csv";
+    const fileContents = "alpha,beta\n1,2\n";
+
+    try {
+      await setupViewportAndOpen("dialog", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          "from pynote_ui import Group, Text, Upload, display",
+          `root = Path('/workspace') / '${rootName}'`,
+          "root.mkdir(parents=True, exist_ok=True)",
+          `uploader = Upload(label='${uploadLabel}', dir='${rootName}')`,
+          "display(Group([",
+          "    Text(content='Upload fixture', border=False),",
+          "    uploader,",
+          `], label='${uploadLabel}', border=True))`,
+          "print('UPLOAD_WIDGET_READY')",
+        ].join("\n"),
+        "UPLOAD_WIDGET_READY",
+      );
+
+      await notebook.uploadFileViaComponent(uploadLabel, {
+        name: fileName,
+        mimeType: "text/csv",
+        buffer: Buffer.from(fileContents, "utf-8"),
+      });
+
+      await expect(notebook.uploadComponent(uploadLabel)).toContainText(fileName, { timeout: 60_000 });
+
+      await notebook.openFilesData("dialog");
+      await notebook.refreshFilesData("dialog");
+      await notebook.filesRow("dialog", rootName).dblclick();
+      await expect(notebook.filesRow("dialog", fileName)).toBeVisible();
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          `file_path = root / '${fileName}'`,
+          "ok = file_path.exists() and file_path.read_text(encoding='utf-8') == 'alpha,beta\\n1,2\\n'",
+          "print('VERIFY_OK_UPLOAD_DIR' if ok else 'VERIFY_FAIL_UPLOAD_DIR')",
+        ].join("\n"),
+        "VERIFY_OK_UPLOAD_DIR",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+
+  test("dialog mode roundtrip: create in code cell, move in panel, verify in code cell", async ({ notebook, page }) => {
+    const rootName = `e2e-fs-dialog-${makeRunId()}`;
+
+    try {
+      await setupViewportAndOpen("dialog", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "import shutil",
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "if root.exists():",
+          "    shutil.rmtree(root)",
+          "(root / 'archive').mkdir(parents=True)",
+          "(root / 'input.csv').write_text('from-input', encoding='utf-8')",
+          "print('SETUP_OK_DIALOG')",
+        ].join("\n"),
+        "SETUP_OK_DIALOG",
+      );
+
+      await notebook.openFilesData("dialog");
+      await notebook.filesRow("dialog", rootName).dblclick();
+      await notebook.dragFileRowTo("dialog", "input.csv", "archive");
+      await expect(notebook.filesRow("dialog", "input.csv")).toHaveCount(0);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "ok = (root / 'archive' / 'input.csv').exists() and not (root / 'input.csv').exists()",
+          "print('VERIFY_OK_DIALOG' if ok else 'VERIFY_FAIL_DIALOG')",
+        ].join("\n"),
+        "VERIFY_OK_DIALOG",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+
+  test("side mode roundtrip: create in code cell, move in panel, verify in code cell", async ({ notebook, page }) => {
+    const rootName = `e2e-fs-side-${makeRunId()}`;
+
+    try {
+      await setupViewportAndOpen("side", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "import shutil",
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "if root.exists():",
+          "    shutil.rmtree(root)",
+          "(root / 'archive').mkdir(parents=True)",
+          "(root / 'input.csv').write_text('from-input', encoding='utf-8')",
+          "print('SETUP_OK_SIDE')",
+        ].join("\n"),
+        "SETUP_OK_SIDE",
+      );
+
+      await notebook.openFilesData("side");
+      await notebook.filesRow("side", rootName).dblclick();
+      await notebook.dragFileRowTo("side", "input.csv", "archive");
+      await expect(notebook.filesRow("side", "input.csv")).toHaveCount(0);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "ok = (root / 'archive' / 'input.csv').exists() and not (root / 'input.csv').exists()",
+          "print('VERIFY_OK_SIDE' if ok else 'VERIFY_FAIL_SIDE')",
+        ].join("\n"),
+        "VERIFY_OK_SIDE",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+
+  test("same-directory drop is no-op and shows no error", async ({ notebook, page }) => {
+    const rootName = `e2e-fs-noop-${makeRunId()}`;
+    const rootPath = `/workspace/${rootName}`;
+
+    try {
+      await setupViewportAndOpen("dialog", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "import shutil",
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "if root.exists():",
+          "    shutil.rmtree(root)",
+          "root.mkdir(parents=True)",
+          "(root / 'same.csv').write_text('same-dir', encoding='utf-8')",
+          "print('SETUP_OK_NOOP')",
+        ].join("\n"),
+        "SETUP_OK_NOOP",
+      );
+
+      await notebook.openFilesData("dialog");
+      await notebook.filesRow("dialog", rootName).dblclick();
+
+      let promptCount = 0;
+      const onDialog = async (dialog: Dialog) => {
+        promptCount += 1;
+        await dialog.accept("skip");
+      };
+      page.on("dialog", onDialog);
+
+      try {
+        await notebook.dragFileRowToBreadcrumb("dialog", "same.csv", rootPath);
+        await expect(notebook.filesPanel("dialog").getByTestId(TESTID.filesPanelError)).toHaveCount(0);
+      } finally {
+        page.off("dialog", onDialog);
+      }
+
+      expect(promptCount).toBe(0);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "ok = (root / 'same.csv').exists()",
+          "print('VERIFY_OK_NOOP' if ok else 'VERIFY_FAIL_NOOP')",
+        ].join("\n"),
+        "VERIFY_OK_NOOP",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+
+  test("name conflict prompt supports replace", async ({ notebook, page }) => {
+    const rootName = `e2e-fs-replace-${makeRunId()}`;
+
+    try {
+      await setupViewportAndOpen("dialog", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "import shutil",
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "if root.exists():",
+          "    shutil.rmtree(root)",
+          "(root / 'dst').mkdir(parents=True)",
+          "(root / 'sample.csv').write_text('src-v1', encoding='utf-8')",
+          "(root / 'dst' / 'sample.csv').write_text('dst-old', encoding='utf-8')",
+          "print('SETUP_OK_REPLACE')",
+        ].join("\n"),
+        "SETUP_OK_REPLACE",
+      );
+
+      await notebook.openFilesData("dialog");
+      await notebook.filesRow("dialog", rootName).dblclick();
+
+      page.once("dialog", async (dialog) => {
+        await dialog.accept("replace");
+      });
+      await notebook.dragFileRowTo("dialog", "sample.csv", "dst");
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "dst_text = (root / 'dst' / 'sample.csv').read_text(encoding='utf-8')",
+          "source_exists = (root / 'sample.csv').exists()",
+          "ok = (dst_text == 'src-v1') and (not source_exists)",
+          "print('VERIFY_OK_REPLACE' if ok else 'VERIFY_FAIL_REPLACE')",
+        ].join("\n"),
+        "VERIFY_OK_REPLACE",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+
+  test("name conflict prompt supports copy", async ({ notebook, page }) => {
+    const rootName = `e2e-fs-copy-${makeRunId()}`;
+
+    try {
+      await setupViewportAndOpen("dialog", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "import shutil",
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "if root.exists():",
+          "    shutil.rmtree(root)",
+          "(root / 'dst').mkdir(parents=True)",
+          "(root / 'sample.csv').write_text('src-v1', encoding='utf-8')",
+          "(root / 'dst' / 'sample.csv').write_text('dst-old', encoding='utf-8')",
+          "print('SETUP_OK_COPY')",
+        ].join("\n"),
+        "SETUP_OK_COPY",
+      );
+
+      await notebook.openFilesData("dialog");
+      await notebook.filesRow("dialog", rootName).dblclick();
+
+      page.once("dialog", async (dialog) => {
+        await dialog.accept("copy");
+      });
+      await notebook.dragFileRowTo("dialog", "sample.csv", "dst");
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "dst_original = (root / 'dst' / 'sample.csv').read_text(encoding='utf-8')",
+          "dst_copy = (root / 'dst' / 'sample (copy).csv').read_text(encoding='utf-8')",
+          "source_exists = (root / 'sample.csv').exists()",
+          "ok = (dst_original == 'dst-old') and (dst_copy == 'src-v1') and (not source_exists)",
+          "print('VERIFY_OK_COPY' if ok else 'VERIFY_FAIL_COPY')",
+        ].join("\n"),
+        "VERIFY_OK_COPY",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+
+  test("name conflict prompt supports skip", async ({ notebook, page }) => {
+    const rootName = `e2e-fs-skip-${makeRunId()}`;
+
+    try {
+      await setupViewportAndOpen("dialog", page, notebook);
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "import shutil",
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "if root.exists():",
+          "    shutil.rmtree(root)",
+          "(root / 'dst').mkdir(parents=True)",
+          "(root / 'sample.csv').write_text('src-v1', encoding='utf-8')",
+          "(root / 'dst' / 'sample.csv').write_text('dst-old', encoding='utf-8')",
+          "print('SETUP_OK_SKIP')",
+        ].join("\n"),
+        "SETUP_OK_SKIP",
+      );
+
+      await notebook.openFilesData("dialog");
+      await notebook.filesRow("dialog", rootName).dblclick();
+
+      page.once("dialog", async (dialog) => {
+        await dialog.accept("skip");
+      });
+      await notebook.dragFileRowTo("dialog", "sample.csv", "dst");
+
+      await runCellAndExpect(
+        page,
+        notebook,
+        [
+          "from pathlib import Path",
+          `root = Path('/workspace') / '${rootName}'`,
+          "dst_original = (root / 'dst' / 'sample.csv').read_text(encoding='utf-8')",
+          "source_text = (root / 'sample.csv').read_text(encoding='utf-8')",
+          "ok = (dst_original == 'dst-old') and (source_text == 'src-v1')",
+          "print('VERIFY_OK_SKIP' if ok else 'VERIFY_FAIL_SKIP')",
+        ].join("\n"),
+        "VERIFY_OK_SKIP",
+      );
+    } finally {
+      await cleanupRoot(page, notebook, rootName);
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
           
           // Also set direct styles as fallback
           document.documentElement.style.backgroundColor = bg;
+          document.body.style.backgroundColor = bg;
           document.documentElement.style.color = text;
           
           // Update meta theme color immediately

--- a/packages/pynote_ui/src/pynote_ui/elements.py
+++ b/packages/pynote_ui/src/pynote_ui/elements.py
@@ -88,6 +88,7 @@ class Text(UIElement):
     Args:
         content: Text string to display (can be updated dynamically)
         size: Size preset ('xs', 'sm', 'md', 'lg')
+        dir: Destination directory under /workspace. Relative paths are resolved from /workspace.
         color: Color theme ('primary', 'secondary', 'accent', etc.)
         align_h: Horizontal alignment ('left', 'center', 'right')
         align_v: Vertical alignment ('top', 'center', 'bottom')
@@ -835,14 +836,19 @@ class Upload(UIElement):
     
     Properties:
         files: Dict of {filename: bytes} for all successfully uploaded files (read-only)
+        workspace_paths: Dict of {filename: '/workspace/filename'} for saved workspace files
     
     Example:
         # Basic usage
-        uploader = Upload(label="Drop CSV files", accept=".csv")
+        # Create the target directory first when using dir=...
+        from pathlib import Path
+        Path("/workspace/data").mkdir(parents=True, exist_ok=True)
+        uploader = Upload(label="Drop CSV files", accept=".csv", dir="data")
         
         def on_file(data):
             for name, content in uploader.files.items():
                 print(f"Got {name}: {len(content)} bytes")
+                print(f"Saved to: {uploader.workspace_paths[name]}")
         
         uploader.on_update(on_file)
         
@@ -851,14 +857,15 @@ class Upload(UIElement):
         submit = Button(label="Send", button_type="submit")
         form = Form([upload, submit], label="Upload Form")
     """
-    def __init__(self, accept=None, max_size=None, label="Upload", color=None, size=None,
+    def __init__(self, accept=None, max_size=None, label="Upload", dir=None, color=None, size=None,
                  disabled=False, width=None, height=None, grow=None, shrink=None,
                  force_dimensions=False, border=True, background=True, hidden=False):
         self._files = {}  # {key: bytes}
+        self._workspace_paths = {}
         self._disabled = disabled
         self._size = size
         super().__init__(
-            accept=accept, max_size=max_size, label=label, color=color, size=size,
+            accept=accept, max_size=max_size, label=label, dir=dir, color=color, size=size,
             disabled=disabled, width=width, height=height, grow=grow, shrink=shrink,
             force_dimensions=force_dimensions, border=border, background=background, hidden=hidden
         )
@@ -867,6 +874,11 @@ class Upload(UIElement):
     def files(self):
         """Dict of {filename: bytes} for all successfully uploaded files."""
         return dict(self._files)
+
+    @property
+    def workspace_paths(self):
+        """Dict of {filename: '/workspace/filename'} for workspace-persisted uploads."""
+        return dict(self._workspace_paths)
 
     @property
     def disabled(self):
@@ -886,7 +898,60 @@ class Upload(UIElement):
         self._size = new_size
         self.send_update(size=new_size)
 
+    def _safe_workspace_name(self, name):
+        name = str(name or "unknown").replace("\\", "/").split("/")[-1].strip()
+        return name or "unknown"
+
+    def _workspace_dir(self):
+        from pathlib import Path
+
+        raw = str(self.props.get("dir") or "/workspace").strip().replace("\\", "/")
+        if not raw:
+            raw = "/workspace"
+        if not raw.startswith("/"):
+            raw = f"/workspace/{raw}"
+
+        parts = []
+        for segment in raw.split("/"):
+            if not segment or segment == ".":
+                continue
+            if segment == "..":
+                if parts:
+                    parts.pop()
+                continue
+            parts.append(segment)
+
+        normalized = "/" + "/".join(parts)
+        if normalized != "/workspace" and not normalized.startswith("/workspace/"):
+            raise ValueError("Upload destination must stay inside /workspace")
+
+        path = Path(normalized)
+        if not path.exists() or not path.is_dir():
+            raise FileNotFoundError(f"Upload destination does not exist: {normalized}")
+        return path
+
+    def _workspace_path_for(self, key):
+        safe_name = self._safe_workspace_name(key)
+        return self._workspace_dir() / safe_name
+
+    def _persist_to_workspace(self, key, raw):
+        path = self._workspace_path_for(key)
+        path.write_bytes(raw)
+        self._workspace_paths[key] = str(path)
+
+    def _remove_from_workspace(self, key):
+        from pathlib import Path
+
+        path_str = self._workspace_paths.pop(key, None)
+        if not path_str:
+            path_str = str(self._workspace_path_for(key))
+
+        path = Path(path_str)
+        if path.exists() and path.is_file():
+            path.unlink()
+
     def handle_interaction(self, data):
+        import base64
         action = data.get("action") if hasattr(data, "get") else None
 
         if action == "upload":
@@ -907,6 +972,7 @@ class Upload(UIElement):
                         status[key] = f"error:File exceeds max size ({max_size} bytes)"
                     else:
                         self._files[key] = raw
+                        self._persist_to_workspace(key, raw)
                         status[key] = "success"
                 except Exception as e:
                     status[key] = f"error:{e}"
@@ -916,6 +982,7 @@ class Upload(UIElement):
         elif action == "remove":
             key = data.get("key", "")
             self._files.pop(key, None)
+            self._remove_from_workspace(key)
             self.send_update(upload_status={key: "removed"})
             super().handle_interaction(data)
 
@@ -937,6 +1004,7 @@ class Upload(UIElement):
                             status[key] = f"error:File exceeds max size ({max_size} bytes)"
                         else:
                             self._files[key] = raw
+                            self._persist_to_workspace(key, raw)
                             status[key] = "success"
                     except Exception as e:
                         status[key] = f"error:{e}"

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,9 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .logo {

--- a/src/components/FileWorkspacePanel.tsx
+++ b/src/components/FileWorkspacePanel.tsx
@@ -1,0 +1,1427 @@
+import { type Component, For, Show, createEffect, createMemo, createSignal, onMount, onCleanup } from "solid-js";
+import { ArrowDownFromLine, ArrowRight, ArrowRightLeft, ChevronDown, ChevronRight, CloudUpload, Copy, Download, File, FileCode2, FileDigit, FileImage, FileMusic, FilePlay, FileSpreadsheet, FileText, Folder, FolderOpen, FolderSymlink, FolderUp, ListChevronsDownUp, ListTree, Pencil, Plus, RotateCw, Trash2 } from "lucide-solid";
+import clsx from "clsx";
+import { kernel } from "../lib/pyodide";
+import { TESTID } from "../lib/testids";
+
+type EntryType = "file" | "dir";
+
+interface FileEntry {
+  name: string;
+  path: string;
+  type: EntryType;
+  size: number;
+  mtime: number;
+}
+
+interface ListResult {
+  path: string;
+  entries: FileEntry[];
+  persistent: boolean;
+}
+
+interface ReadTextResult {
+  text: string;
+  truncated: boolean;
+}
+
+interface DownloadResult {
+  name: string;
+  mime: string;
+  data_base64: string;
+}
+
+type MoveConflictChoice = "replace" | "keep_both" | "skip";
+type FileListViewMode = "list" | "tree";
+
+interface ClipboardEntry {
+  sourcePath: string;
+  name: string;
+}
+
+interface TreeVisibleRow {
+  entry: FileEntry;
+  depth: number;
+}
+
+interface FileWorkspacePanelProps {
+  mode: "side" | "dialog";
+  viewMode: FileListViewMode;
+  onViewModeChange: (nextMode: FileListViewMode) => void;
+}
+
+const WORKSPACE_ROOT = "/workspace";
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const formatDate = (value: number): string => {
+  if (!value) return "-";
+  return new Date(value).toLocaleString();
+};
+
+const toBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result || "");
+      const base64 = result.split(",")[1] ?? "";
+      resolve(base64);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+};
+
+const parentPath = (path: string): string => {
+  if (path === WORKSPACE_ROOT) return WORKSPACE_ROOT;
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length <= 1) return WORKSPACE_ROOT;
+  return `/${parts.slice(0, -1).join("/")}`;
+};
+
+const basename = (path: string): string => {
+  const parts = path.split("/").filter(Boolean);
+  return parts[parts.length - 1] || "";
+};
+
+const splitBreadcrumbs = (path: string): Array<{ label: string; path: string }> => {
+  const clean = path.split("/").filter(Boolean);
+  const out: Array<{ label: string; path: string }> = [];
+  out.push({ label: "workspace", path: WORKSPACE_ROOT });
+  for (let i = 1; i < clean.length; i += 1) {
+    out.push({ label: clean[i], path: `/${clean.slice(0, i + 1).join("/")}` });
+  }
+  return out;
+};
+
+const getFileExtension = (name: string): string => {
+  const dotIndex = name.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === name.length - 1) return "";
+  return name.slice(dotIndex + 1).toLowerCase();
+};
+
+const imageExtensions = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "tif", "tiff", "ico", "heic", "heif"]);
+const tabularDataExtensions = new Set(["csv", "tsv", "xls", "xlsx", "ods", "parquet", "feather", "arrow"]);
+const structuredDataExtensions = new Set(["json", "jsonl", "ndjson", "yaml", "yml", "toml", "xml", "sql", "db", "sqlite", "sqlite3"]);
+const documentExtensions = new Set(["txt", "md", "rst", "tex", "pdf", "doc", "docx", "rtf"]);
+const codeExtensions = new Set(["ipynb", "py", "r", "jl", "js", "jsx", "ts", "tsx", "java", "cpp", "c", "cs", "go", "rs", "sh", "bash"]);
+const audioExtensions = new Set(["mp3", "wav", "flac", "aac", "ogg", "m4a"]);
+const videoExtensions = new Set(["mp4", "mov", "mkv", "avi", "webm", "m4v", "wmv", "flv"]);
+
+const getFileIcon = (name: string) => {
+  const ext = getFileExtension(name);
+  if (imageExtensions.has(ext)) return FileImage;
+  if (tabularDataExtensions.has(ext)) return FileSpreadsheet;
+  if (structuredDataExtensions.has(ext)) return FileDigit;
+  if (audioExtensions.has(ext)) return FileMusic;
+  if (videoExtensions.has(ext)) return FilePlay;
+  if (codeExtensions.has(ext)) return FileCode2;
+  if (documentExtensions.has(ext)) return FileText;
+  return File;
+};
+
+const FileWorkspacePanel: Component<FileWorkspacePanelProps> = (props) => {
+  let panelRootRef: HTMLDivElement | undefined;
+  let uploadInputRef: HTMLInputElement | undefined;
+  let editingInputRef: HTMLInputElement | undefined;
+  let renameHoldTimer: ReturnType<typeof setTimeout> | null = null;
+  let actionMessageTimer: ReturnType<typeof setTimeout> | null = null;
+  let dragGhostEl: HTMLDivElement | null = null;
+
+  const [currentPath, setCurrentPath] = createSignal(WORKSPACE_ROOT);
+  const [entries, setEntries] = createSignal<FileEntry[]>([]);
+  const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
+  const [selectedPaths, setSelectedPaths] = createSignal<string[]>([]);
+  const [selectionAnchorPath, setSelectionAnchorPath] = createSignal<string | null>(null);
+  const [persistenceEnabled, setPersistenceEnabled] = createSignal(false);
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [draggedPath, setDraggedPath] = createSignal<string | null>(null);
+  const [dragOverDirPath, setDragOverDirPath] = createSignal<string | null>(null);
+  const [dragOverBreadcrumbPath, setDragOverBreadcrumbPath] = createSignal<string | null>(null);
+  const [editingPath, setEditingPath] = createSignal<string | null>(null);
+  const [editingName, setEditingName] = createSignal("");
+  const [clipboardEntries, setClipboardEntries] = createSignal<ClipboardEntry[]>([]);
+  const [actionMessage, setActionMessage] = createSignal<string | null>(null);
+  const [treeEntries, setTreeEntries] = createSignal<FileEntry[]>([]);
+  const [expandedDirPaths, setExpandedDirPaths] = createSignal<string[]>([WORKSPACE_ROOT]);
+  const viewMode = () => props.viewMode;
+
+  const panelColumnTemplate = "grid-cols-[minmax(0,1fr)_6.5rem]";
+  const dialogColumnTemplate = "grid-cols-[minmax(0,1fr)_6.5rem_10.5rem]";
+  const dialogBorderBottom = "[border-bottom-width:var(--ui-border-width,1px)] [border-bottom-style:var(--ui-border-style,solid)] border-[var(--ui-border-color,var(--foreground))]";
+  const dialogBorderTop = "[border-top-width:var(--ui-border-width,1px)] [border-top-style:var(--ui-border-style,solid)] border-[var(--ui-border-color,var(--foreground))]";
+
+  const selectedPathSet = createMemo(() => new Set(selectedPaths()));
+  const selectableEntries = createMemo(() => (viewMode() === "tree" ? treeEntries() : entries()));
+  const selectedEntries = createMemo(() => selectableEntries().filter((entry) => selectedPathSet().has(entry.path)));
+  const selectedEntry = createMemo(() => (selectedEntries().length === 1 ? selectedEntries()[0] : null));
+  const selectedFolderEntry = createMemo(() => {
+    const selected = selectedEntry();
+    return selected?.type === "dir" ? selected : null;
+  });
+  const breadcrumbs = createMemo(() => splitBreadcrumbs(currentPath()));
+  const parentDirPath = createMemo(() => parentPath(currentPath()));
+  const expandedDirPathSet = createMemo(() => new Set(expandedDirPaths()));
+  const isSelectedFolderExpanded = createMemo(() => {
+    const selected = selectedFolderEntry();
+    return !!selected && expandedDirPathSet().has(selected.path);
+  });
+  const treeChildrenByParent = createMemo(() => {
+    const grouped = new Map<string, FileEntry[]>();
+    for (const entry of treeEntries()) {
+      const parent = parentPath(entry.path);
+      if (!grouped.has(parent)) grouped.set(parent, []);
+      grouped.get(parent)!.push(entry);
+    }
+    for (const [, children] of grouped) {
+      children.sort((a, b) => {
+        if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+    }
+    return grouped;
+  });
+  const visibleTreeRows = createMemo<TreeVisibleRow[]>(() => {
+    if (viewMode() !== "tree") return [];
+    const out: TreeVisibleRow[] = [];
+    const walk = (parent: string, depth: number) => {
+      const children = treeChildrenByParent().get(parent) || [];
+      for (const child of children) {
+        out.push({ entry: child, depth });
+        if (child.type === "dir" && expandedDirPathSet().has(child.path)) {
+          walk(child.path, depth + 1);
+        }
+      }
+    };
+    walk(WORKSPACE_ROOT, 0);
+    return out;
+  });
+
+  const indexByPath = createMemo(() => {
+    const map = new Map<string, number>();
+    const orderedEntries = viewMode() === "tree" ? visibleTreeRows().map((row) => row.entry) : entries();
+    orderedEntries.forEach((entry, index) => map.set(entry.path, index));
+    return map;
+  });
+
+  const flashAction = (shortMessage: string, detailMessage?: string) => {
+    setActionMessage(props.mode === "side" ? shortMessage : (detailMessage || shortMessage));
+    if (actionMessageTimer) {
+      clearTimeout(actionMessageTimer);
+      actionMessageTimer = null;
+    }
+    actionMessageTimer = setTimeout(() => {
+      setActionMessage(null);
+      actionMessageTimer = null;
+    }, 1400);
+  };
+
+  const refreshList = async (targetPath?: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await kernel.filesystem<ListResult>({
+        op: "list",
+        path: targetPath || currentPath(),
+      });
+      setCurrentPath(result.path);
+      setEntries(result.entries);
+      setPersistenceEnabled(result.persistent);
+      const nextSelectedPaths = selectedPaths().filter((path) => result.entries.some((e) => e.path === path));
+      setSelectedPaths(nextSelectedPaths);
+      setSelectedPath((prev) => (prev && result.entries.some((e) => e.path === prev) ? prev : (nextSelectedPaths[0] || null)));
+      setSelectionAnchorPath((prev) => (prev && result.entries.some((e) => e.path === prev) ? prev : null));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load files");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const refreshTree = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const collected: FileEntry[] = [];
+      const listRecursive = async (path: string) => {
+        const result = await kernel.filesystem<ListResult>({ op: "list", path });
+        if (path === WORKSPACE_ROOT) setPersistenceEnabled(result.persistent);
+        for (const entry of result.entries) {
+          collected.push(entry);
+          if (entry.type === "dir") {
+            await listRecursive(entry.path);
+          }
+        }
+      };
+
+      await listRecursive(WORKSPACE_ROOT);
+      setCurrentPath(WORKSPACE_ROOT);
+      setTreeEntries(collected);
+
+      const treePathSet = new Set(collected.map((entry) => entry.path));
+      const nextSelectedPaths = selectedPaths().filter((path) => treePathSet.has(path));
+      setSelectedPaths(nextSelectedPaths);
+      setSelectedPath((prev) => (prev && treePathSet.has(prev) ? prev : (nextSelectedPaths[0] || null)));
+      setSelectionAnchorPath((prev) => (prev && treePathSet.has(prev) ? prev : null));
+      setExpandedDirPaths((prev) => {
+        const next = prev.filter((path) => path === WORKSPACE_ROOT || treePathSet.has(path));
+        return next.includes(WORKSPACE_ROOT) ? next : [WORKSPACE_ROOT, ...next];
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load files");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const refresh = async (targetPath?: string) => {
+    if (viewMode() === "tree") {
+      await refreshTree();
+      return;
+    }
+    await refreshList(targetPath);
+  };
+
+  const openDirectory = async (path: string) => {
+    if (viewMode() === "tree") {
+      setExpandedDirPaths((prev) => (prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]));
+      return;
+    }
+    await refresh(path);
+  };
+
+  const previewFile = async (path: string) => {
+    setSelectedPath(path);
+    setSelectedPaths([path]);
+    await kernel.filesystem<ReadTextResult>({
+      op: "read_text",
+      path,
+      maxBytes: 32,
+    }).catch(() => undefined);
+  };
+
+  const openEntry = async (entry: FileEntry) => {
+    if (entry.type === "dir") {
+      await openDirectory(entry.path);
+      return;
+    }
+    await previewFile(entry.path);
+  };
+
+  const createFolder = async () => {
+    const name = window.prompt("New folder name", "data");
+    if (!name) return;
+    try {
+      const selected = selectedEntry();
+      const targetDir = viewMode() === "tree" && selected?.type === "dir" ? selected.path : currentPath();
+      await kernel.filesystem({
+        op: "mkdir",
+        path: `${targetDir}/${name}`,
+      });
+      if (viewMode() === "tree") {
+        setExpandedDirPaths((prev) => (prev.includes(targetDir) ? prev : [...prev, targetDir]));
+      }
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create folder");
+    }
+  };
+
+  const expandSelectedFolder = async () => {
+    const selected = selectedFolderEntry();
+    if (!selected) return;
+
+    if (viewMode() !== "tree") {
+      props.onViewModeChange("tree");
+      await refreshTree();
+    }
+
+    const nextExpanded = new Set(expandedDirPaths());
+    nextExpanded.add(selected.path);
+
+    const walk = (parent: string, depth: number) => {
+      if (depth >= 10) return;
+      const children = treeChildrenByParent().get(parent) || [];
+      for (const child of children) {
+        if (child.type !== "dir") continue;
+        nextExpanded.add(child.path);
+        walk(child.path, depth + 1);
+      }
+    };
+
+    walk(selected.path, 0);
+    setExpandedDirPaths(Array.from(nextExpanded));
+  };
+
+  const collapseSelectedFolder = () => {
+    const selected = selectedFolderEntry();
+    if (!selected) return;
+
+    const nextExpanded = new Set(expandedDirPaths());
+    const walk = (parent: string, depth: number) => {
+      if (depth >= 10) return;
+      const children = treeChildrenByParent().get(parent) || [];
+      for (const child of children) {
+        if (child.type !== "dir") continue;
+        nextExpanded.delete(child.path);
+        walk(child.path, depth + 1);
+      }
+    };
+
+    walk(selected.path, 0);
+    nextExpanded.delete(selected.path);
+    nextExpanded.add(WORKSPACE_ROOT);
+    setExpandedDirPaths(Array.from(nextExpanded));
+  };
+
+  const toggleExpandCollapseSelectedFolder = async () => {
+    if (isSelectedFolderExpanded()) {
+      collapseSelectedFolder();
+      return;
+    }
+    await expandSelectedFolder();
+  };
+
+  const uploadFiles = async (fileList: FileList | null, targetDir?: string) => {
+    if (!fileList || fileList.length === 0) return;
+    try {
+      const files = await Promise.all(
+        Array.from(fileList).map(async (file) => ({
+          name: file.name,
+          data_base64: await toBase64(file),
+        })),
+      );
+      await kernel.filesystem({
+        op: "upload",
+        path: targetDir || currentPath(),
+        files,
+      });
+      flashAction("Uploaded", `Uploaded ${files.length} file${files.length === 1 ? "" : "s"}`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to upload files");
+    } finally {
+      if (uploadInputRef) uploadInputRef.value = "";
+    }
+  };
+
+  const deleteEntry = async (entry: FileEntry) => {
+    const ok = window.confirm(`Delete ${entry.name}? This cannot be undone.`);
+    if (!ok) return;
+    try {
+      await kernel.filesystem({ op: "delete", path: entry.path });
+      setSelectedPath((prev) => (prev === entry.path ? null : prev));
+      setSelectedPaths((prev) => prev.filter((path) => path !== entry.path));
+      flashAction("Deleted", `Deleted ${entry.name}`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete entry");
+    }
+  };
+
+  const renameEntry = async (entry: FileEntry) => {
+    const nextName = window.prompt("Rename to", entry.name);
+    if (!nextName || nextName === entry.name) return;
+    try {
+      await kernel.filesystem({ op: "rename", path: entry.path, newName: nextName });
+      flashAction("Renamed", `Renamed to ${nextName}`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to rename entry");
+    }
+  };
+
+  const moveEntry = async (entry: FileEntry) => {
+    const destination = window.prompt("Move to directory path", currentPath());
+    if (!destination) return;
+    try {
+      await kernel.filesystem({ op: "move", sourcePath: entry.path, destinationDir: destination });
+      setSelectedPath((prev) => (prev === entry.path ? null : prev));
+      setSelectedPaths((prev) => prev.filter((path) => path !== entry.path));
+      flashAction("Moved", `Moved ${entry.name}`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to move entry");
+    }
+  };
+
+  const copyEntry = async (entry: FileEntry) => {
+    const destination = window.prompt("Copy to directory path", currentPath());
+    if (!destination) return;
+    try {
+      await kernel.filesystem({ op: "copy", sourcePath: entry.path, destinationDir: destination });
+      flashAction("Copied", `Copied ${entry.name}`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to copy entry");
+    }
+  };
+
+  const downloadEntry = async (entry: FileEntry) => {
+    if (entry.type !== "file") return;
+    try {
+      const result = await kernel.filesystem<DownloadResult>({ op: "download", path: entry.path });
+      const binary = atob(result.data_base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+      const blob = new Blob([bytes], { type: result.mime || "application/octet-stream" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = result.name;
+      a.click();
+      URL.revokeObjectURL(url);
+      flashAction("Downloaded", `Downloaded ${entry.name}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to download file");
+    }
+  };
+
+  onMount(() => {
+    const onDocumentPointerDown = (event: PointerEvent) => {
+      const root = panelRootRef;
+      if (!root) return;
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (root.contains(target)) return;
+      if (!selectedPath() && selectedPaths().length === 0) return;
+      clearSelection();
+    };
+
+    document.addEventListener("pointerdown", onDocumentPointerDown);
+    onCleanup(() => {
+      document.removeEventListener("pointerdown", onDocumentPointerDown);
+    });
+
+    if (viewMode() === "tree") {
+      void refreshTree();
+      return;
+    }
+    void refreshList(WORKSPACE_ROOT);
+  });
+
+  onCleanup(() => {
+    if (renameHoldTimer) {
+      clearTimeout(renameHoldTimer);
+      renameHoldTimer = null;
+    }
+    if (actionMessageTimer) {
+      clearTimeout(actionMessageTimer);
+      actionMessageTimer = null;
+    }
+    if (dragGhostEl) {
+      dragGhostEl.remove();
+      dragGhostEl = null;
+    }
+  });
+
+  const deleteSelectedEntry = async () => {
+    const selected = selectedEntries();
+    if (selected.length === 0) return;
+    if (selected.length === 1) {
+      await deleteEntry(selected[0]);
+      return;
+    }
+
+    const ok = window.confirm(`Delete ${selected.length} items? This cannot be undone.`);
+    if (!ok) return;
+
+    try {
+      for (const entry of selected) {
+        await kernel.filesystem({ op: "delete", path: entry.path });
+      }
+      setSelectedPath(null);
+      setSelectedPaths([]);
+      setSelectionAnchorPath(null);
+      flashAction("Deleted", `Deleted ${selected.length} items`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete selected entries");
+    }
+  };
+
+  const armHoldRename = (entry: FileEntry, e: PointerEvent) => {
+    if (e.shiftKey || e.metaKey || e.ctrlKey || selectedEntries().length > 1) return;
+    if (renameHoldTimer) clearTimeout(renameHoldTimer);
+    renameHoldTimer = setTimeout(() => {
+      setSelectedPath(entry.path);
+      setSelectedPaths([entry.path]);
+      setSelectionAnchorPath(entry.path);
+      setEditingPath(entry.path);
+      setEditingName(entry.name);
+      renameHoldTimer = null;
+    }, 500);
+  };
+
+  const clearHoldRename = () => {
+    if (renameHoldTimer) {
+      clearTimeout(renameHoldTimer);
+      renameHoldTimer = null;
+    }
+  };
+
+  const clearSelection = () => {
+    setSelectedPath(null);
+    setSelectedPaths([]);
+    setSelectionAnchorPath(null);
+  };
+
+  const commitInlineRename = async (entry: FileEntry) => {
+    const nextName = editingName().trim();
+    setEditingPath(null);
+
+    if (!nextName || nextName === entry.name) {
+      setEditingName("");
+      return;
+    }
+
+    try {
+      const result = await kernel.filesystem<{ ok: boolean; path: string }>({ op: "rename", path: entry.path, newName: nextName });
+      setSelectedPath(result.path);
+      setSelectedPaths([result.path]);
+      setSelectionAnchorPath(result.path);
+      setEditingName("");
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to rename entry");
+      setEditingName("");
+    }
+  };
+
+  const cancelInlineRename = () => {
+    setEditingPath(null);
+    setEditingName("");
+  };
+
+  const copySelectedToClipboard = () => {
+    const selected = selectedEntries();
+    if (selected.length === 0) return;
+    setClipboardEntries(selected.map((entry) => ({ sourcePath: entry.path, name: entry.name })));
+    flashAction("Copied", `Copied ${selected.length} item${selected.length === 1 ? "" : "s"}`);
+  };
+
+  const pasteClipboardToCurrentDirectory = async () => {
+    const clips = clipboardEntries();
+    if (clips.length === 0) return;
+    try {
+      for (const clip of clips) {
+        await kernel.filesystem({ op: "copy", sourcePath: clip.sourcePath, destinationDir: currentPath() });
+      }
+      flashAction("Pasted", `Pasted ${clips.length} item${clips.length === 1 ? "" : "s"}`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to paste entry");
+    }
+  };
+
+  const moveSelectedEntries = async () => {
+    const selected = selectedEntries();
+    if (selected.length === 0) return;
+    if (selected.length === 1) {
+      await moveEntry(selected[0]);
+      return;
+    }
+
+    const destination = window.prompt("Move selected items to directory path", currentPath());
+    if (!destination) return;
+    try {
+      for (const entry of selected) {
+        await kernel.filesystem({ op: "move", sourcePath: entry.path, destinationDir: destination });
+      }
+      setSelectedPath(null);
+      setSelectedPaths([]);
+      setSelectionAnchorPath(null);
+      flashAction("Moved", `Moved ${selected.length} items`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to move selected entries");
+    }
+  };
+
+  const copySelectedEntries = async () => {
+    const selected = selectedEntries();
+    if (selected.length === 0) return;
+    if (selected.length === 1) {
+      await copyEntry(selected[0]);
+      return;
+    }
+
+    const destination = window.prompt("Copy selected items to directory path", currentPath());
+    if (!destination) return;
+    try {
+      for (const entry of selected) {
+        await kernel.filesystem({ op: "copy", sourcePath: entry.path, destinationDir: destination });
+      }
+      flashAction("Copied", `Copied ${selected.length} items`);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to copy selected entries");
+    }
+  };
+
+  createEffect(() => {
+    const activeEditingPath = editingPath();
+    if (!activeEditingPath) return;
+    const scheduleFocus = () => {
+      const input = editingInputRef;
+      if (!input) return;
+      input.focus();
+      const len = input.value.length;
+      input.setSelectionRange(len, len);
+    };
+    queueMicrotask(scheduleFocus);
+    requestAnimationFrame(scheduleFocus);
+  });
+
+  const handleEntryDragStart = (entry: FileEntry, e: DragEvent, rowEl: HTMLDivElement) => {
+    clearHoldRename();
+    if (editingPath() === entry.path) {
+      cancelInlineRename();
+    }
+    setDraggedPath(entry.path);
+
+    if (dragGhostEl) {
+      dragGhostEl.remove();
+      dragGhostEl = null;
+    }
+
+    const rowLabel = rowEl.querySelector("span.truncate");
+    const labelStyles = rowLabel ? getComputedStyle(rowLabel) : getComputedStyle(rowEl);
+
+    const ghost = document.createElement("div");
+    ghost.style.position = "fixed";
+    ghost.style.top = "0";
+    ghost.style.left = "0";
+    ghost.style.transform = "translate(-10000px, -10000px)";
+    ghost.style.pointerEvents = "none";
+    ghost.style.display = "inline-flex";
+    ghost.style.alignItems = "center";
+    ghost.style.gap = "6px";
+    ghost.style.maxWidth = "260px";
+    ghost.style.padding = "4px 8px";
+    ghost.style.borderRadius = "6px";
+    ghost.style.background = "color-mix(in srgb, var(--foreground) 12%, transparent)";
+    ghost.style.border = "1px solid color-mix(in srgb, var(--foreground) 24%, transparent)";
+    ghost.style.color = labelStyles.color;
+    ghost.style.fontFamily = labelStyles.fontFamily;
+    ghost.style.fontSize = labelStyles.fontSize;
+    ghost.style.fontWeight = labelStyles.fontWeight;
+    ghost.style.letterSpacing = labelStyles.letterSpacing;
+    ghost.style.lineHeight = labelStyles.lineHeight;
+    ghost.style.opacity = "1";
+    ghost.style.filter = "none";
+    ghost.style.textRendering = "geometricPrecision";
+
+    const sourceIcon = rowEl.querySelector("svg");
+    if (sourceIcon) {
+      const iconClone = sourceIcon.cloneNode(true) as SVGElement;
+      iconClone.setAttribute("width", "13");
+      iconClone.setAttribute("height", "13");
+      ghost.appendChild(iconClone);
+    }
+
+    const label = document.createElement("span");
+    label.textContent = entry.name;
+    label.style.overflow = "hidden";
+    label.style.textOverflow = "ellipsis";
+    label.style.whiteSpace = "nowrap";
+    label.style.opacity = "1";
+    label.style.filter = "none";
+    label.style.fontWeight = labelStyles.fontWeight;
+    ghost.appendChild(label);
+
+    document.body.appendChild(ghost);
+    dragGhostEl = ghost;
+
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", entry.path);
+      e.dataTransfer.setDragImage(ghost, 10, 10);
+    }
+  };
+
+  const handleEntryDragEnd = () => {
+    setDraggedPath(null);
+    setDragOverDirPath(null);
+    setDragOverBreadcrumbPath(null);
+    if (dragGhostEl) {
+      dragGhostEl.remove();
+      dragGhostEl = null;
+    }
+  };
+
+  const moveDraggedEntryToDirectory = async (destinationDir: string, sourceOverride?: string | null) => {
+    const sourcePath = sourceOverride || draggedPath();
+    if (!sourcePath || sourcePath === destinationDir) return;
+    if (parentPath(sourcePath) === destinationDir) return;
+    try {
+      await kernel.filesystem({ op: "move", sourcePath, destinationDir });
+      if (selectedPath() === sourcePath) setSelectedPath(null);
+      setSelectedPaths((prev) => prev.filter((path) => path !== sourcePath));
+      flashAction("Moved", "Moved item");
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to move entry";
+      if (message === "Target already exists") {
+        const itemName = basename(sourcePath) || "item";
+        const rawChoice = window.prompt(
+          `An item named ${itemName} already exists here. Type: replace, copy, or skip`,
+          "skip",
+        );
+
+        if (!rawChoice) return;
+        const choice = rawChoice.trim().toLowerCase();
+        const conflictChoice: MoveConflictChoice | null =
+          choice === "replace" ? "replace" : choice === "copy" ? "keep_both" : choice === "skip" ? "skip" : null;
+
+        if (!conflictChoice) {
+          setError("Invalid choice. Type replace, copy, or skip.");
+          return;
+        }
+
+        if (conflictChoice === "skip") {
+          return;
+        }
+
+        try {
+          await kernel.filesystem({ op: "move", sourcePath, destinationDir, onConflict: conflictChoice });
+          if (selectedPath() === sourcePath) setSelectedPath(null);
+          setSelectedPaths((prev) => prev.filter((path) => path !== sourcePath));
+          flashAction(conflictChoice === "replace" ? "Replaced" : "Copied", conflictChoice === "replace" ? "Replaced item" : "Saved copy");
+          await refresh();
+          return;
+        } catch (conflictErr) {
+          setError(conflictErr instanceof Error ? conflictErr.message : "Failed to resolve move conflict");
+          return;
+        }
+      }
+
+      setError(message);
+    }
+  };
+
+  const handlePanelDrop = async (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverDirPath(null);
+    setDragOverBreadcrumbPath(null);
+    const dt = e.dataTransfer;
+    if (!dt) return;
+
+    if (dt.files && dt.files.length > 0) {
+      await uploadFiles(dt.files, viewMode() === "tree" ? WORKSPACE_ROOT : undefined);
+      return;
+    }
+
+    const sourcePath = dt.getData("text/plain") || draggedPath();
+    if (sourcePath) {
+      await moveDraggedEntryToDirectory(viewMode() === "tree" ? WORKSPACE_ROOT : currentPath(), sourcePath);
+    }
+  };
+
+  const toggleViewMode = () => {
+    const nextMode: FileListViewMode = viewMode() === "list" ? "tree" : "list";
+    props.onViewModeChange(nextMode);
+    if (nextMode === "tree") {
+      setCurrentPath(WORKSPACE_ROOT);
+      if (!expandedDirPathSet().has(WORKSPACE_ROOT)) {
+        setExpandedDirPaths((prev) => [WORKSPACE_ROOT, ...prev]);
+      }
+      void refreshTree();
+      return;
+    }
+    void refreshList(currentPath());
+  };
+
+  const Breadcrumbs: Component = () => (
+    <div class="flex flex-wrap items-center gap-1">
+        {">"}
+      <For each={breadcrumbs()}>
+        {(crumb, index) => (
+          <>
+            <Show when={index() > 0}>
+              <span class="text-secondary/50 select-none">/</span>
+            </Show>
+            <button
+              data-testid={TESTID.filesPanelBreadcrumb}
+              data-path={crumb.path}
+              class={clsx(
+                "px-1.5 py-0.5 rounded-sm bg-foreground/53 hover:bg-foreground",
+                index() === breadcrumbs().length - 1 && "font-semibold",
+                dragOverBreadcrumbPath() === crumb.path && "ring-1 ring-inset ring-accent/70 bg-foreground",
+              )}
+              onClick={() => void openDirectory(crumb.path)}
+              title={`Open ${crumb.path}`}
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setDragOverDirPath(null);
+                setDragOverBreadcrumbPath(crumb.path);
+              }}
+              onDragLeave={(e) => {
+                const related = e.relatedTarget as Node | null;
+                if (related && (e.currentTarget as HTMLButtonElement).contains(related)) return;
+                if (dragOverBreadcrumbPath() === crumb.path) setDragOverBreadcrumbPath(null);
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setDragOverBreadcrumbPath(null);
+                setDragOverDirPath(null);
+
+                const dt = e.dataTransfer;
+                if (!dt) return;
+
+                if (dt.files && dt.files.length > 0) {
+                  void uploadFiles(dt.files, crumb.path);
+                  return;
+                }
+
+                const sourcePath = dt.getData("text/plain") || draggedPath();
+                void moveDraggedEntryToDirectory(crumb.path, sourcePath);
+              }}
+            >
+              {crumb.label}
+            </button>
+          </>
+        )}
+      </For>
+    </div>
+  );
+
+  return (
+    <div
+      ref={panelRootRef}
+      tabIndex={0}
+      data-testid={TESTID.filesPanelRoot}
+      data-mode={props.mode}
+      class={clsx(
+        "flex flex-col gap-3 rounded-sm outline-none",
+        props.mode === "side" ? "text-xs" : "text-sm",
+      )}
+      onKeyDown={(e) => {
+        if (editingPath()) return;
+        const key = e.key.toLowerCase();
+        const hasCommandModifier = e.metaKey || e.ctrlKey;
+        if (!hasCommandModifier || e.altKey || e.shiftKey) return;
+
+        if (key === "c") {
+          if (selectedEntries().length === 0) return;
+          e.preventDefault();
+          e.stopPropagation();
+          copySelectedToClipboard();
+          return;
+        }
+
+        if (key === "v") {
+          if (clipboardEntries().length === 0) return;
+          e.preventDefault();
+          e.stopPropagation();
+          void pasteClipboardToCurrentDirectory();
+        }
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+      }}
+      onDrop={(e) => {
+        void handlePanelDrop(e);
+      }}
+    >
+      <div class={clsx("flex items-center gap-2", props.mode === "side" ? "justify-start" : "justify-between")}>
+        <div class="flex items-center gap-2.5">
+          <h3 class="font-bold uppercase tracking-wide text-secondary/80">Files and Data</h3>
+          <Show when={props.mode === "side"}>
+            <span
+              class={clsx("inline-block w-2 h-2 rounded-full", persistenceEnabled() ? "bg-success" : "bg-warning")}
+              title={persistenceEnabled() ? "Persistent" : "Session memory"}
+              aria-label={persistenceEnabled() ? "Persistent" : "Session memory"}
+            />
+          </Show>
+        </div>
+
+        <Show when={props.mode === "dialog"}>
+          <div class={clsx("text-[10px] text-right", persistenceEnabled() ? "text-success" : "text-warning")}>
+            {persistenceEnabled() ? "Persistent" : "Session memory"}
+          </div>
+        </Show>
+      </div>
+
+      <input
+        ref={uploadInputRef}
+        type="file"
+        multiple
+        class="hidden"
+        onChange={(e) => {
+          void uploadFiles(e.currentTarget.files);
+        }}
+      />
+
+      <Show when={error()}>
+        <div data-testid={TESTID.filesPanelError} class="rounded-sm ui-border border-primary/60 bg-primary/10 p-2 text-primary text-[11px]">{error()}</div>
+      </Show>
+
+      <div
+        class={clsx(
+          "rounded-sm ui-border overflow-hidden",
+          props.mode === "side" && "border-secondary/25",
+        )}
+      >
+        <div class={clsx("bg-foreground/53 px-2 py-1.5 flex items-center gap-1.5", props.mode === "dialog" && dialogBorderBottom)}>
+          <Show
+            when={props.mode === "dialog"}
+            fallback={
+              <>
+                <button
+                  class="w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center"
+                  title="Upload files"
+                  aria-label="Upload files"
+                  onClick={() => uploadInputRef?.click()}
+                >
+                  <CloudUpload size={14} />
+                </button>
+                <button
+                  class="w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center"
+                  title={viewMode() === "list" ? "Switch to tree view" : "Switch to list view"}
+                  aria-label={viewMode() === "list" ? "Switch to tree view" : "Switch to list view"}
+                  onClick={toggleViewMode}
+                >
+                  <Show when={viewMode() === "list"} fallback={<FolderSymlink size={14} />}>
+                    <ListTree size={14} />
+                  </Show>
+                </button>
+                <button
+                  class="w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center"
+                  title="Refresh"
+                  aria-label="Refresh"
+                  onClick={() => void refresh()}
+                >
+                  <RotateCw size={14} />
+                </button>
+              </>
+            }
+          >
+            <button class="px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1" onClick={() => uploadInputRef?.click()}><CloudUpload size={13} /> Upload</button>
+            <button class="px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1" onClick={toggleViewMode} title={viewMode() === "list" ? "Switch to tree view" : "Switch to list view"}>
+              <Show when={viewMode() === "list"} fallback={<><FolderSymlink size={13} /> List</>}>
+                <><ListTree size={13} /> Tree</>
+              </Show>
+            </button>
+            <button class="px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1" onClick={() => void refresh()}><RotateCw size={13} /> Refresh</button>
+          </Show>
+          <Show when={actionMessage()}>
+            <div class="ml-auto text-[10px] text-secondary/70 truncate" title={actionMessage() || ""}>{actionMessage()}</div>
+          </Show>
+        </div>
+
+        <div
+          class={clsx(
+            "bg-background/70 px-2 flex items-center gap-2 overflow-hidden transition-all duration-200 ease-out",
+            viewMode() === "tree" ? "h-0 py-0 opacity-0 -translate-y-1 pointer-events-none" : "h-9 py-1.5 opacity-100 translate-y-0",
+          )}
+        >
+          <div class="min-w-0 flex-1">
+            <Breadcrumbs />
+          </div>
+        </div>
+
+        <div
+          class={clsx(
+            "px-2 py-1 text-[11px] uppercase text-secondary/60 bg-foreground/35 border-t border-secondary/40 grid gap-2",
+            props.mode === "dialog" ? dialogColumnTemplate : panelColumnTemplate,
+            props.mode === "dialog" && dialogBorderTop,
+          )}
+        >
+          <div>Name</div>
+          <div class="text-right">Size</div>
+          <Show when={props.mode === "dialog"}>
+            <div class="text-right">Modified</div>
+          </Show>
+        </div>
+
+        <div
+          class={clsx(
+            "bg-background/55",
+            props.mode === "side" && "max-h-[58vh] overflow-y-auto",
+            props.mode === "dialog" && "max-h-[48vh]",
+          )}
+          onPointerDown={(e) => {
+            if (e.target !== e.currentTarget) return;
+            if (editingPath()) return;
+            clearSelection();
+          }}
+        >
+          <Show when={viewMode() === "list" && currentPath() !== WORKSPACE_ROOT}>
+            <div
+              data-testid={TESTID.filesPanelRow}
+              data-entry-path={parentDirPath()}
+              data-entry-name=".."
+              data-entry-type="dir"
+              class={clsx(
+                "group grid gap-2 px-2 py-1 cursor-pointer",
+                props.mode === "dialog" ? dialogColumnTemplate : panelColumnTemplate,
+                "bg-foreground/10 hover:bg-foreground/25",
+                dragOverDirPath() === parentDirPath() && "ring-1 ring-accent/70 bg-foreground!",
+              )}
+              onClick={() => {
+                panelRootRef?.focus({ preventScroll: true });
+                void openDirectory(parentDirPath());
+              }}
+              onDblClick={() => {
+                void openDirectory(parentDirPath());
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOverDirPath(parentDirPath());
+              }}
+              onDragLeave={(e) => {
+                const related = e.relatedTarget as Node | null;
+                if (related && (e.currentTarget as HTMLDivElement).contains(related)) return;
+                if (dragOverDirPath() === parentDirPath()) setDragOverDirPath(null);
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setDragOverDirPath(null);
+                const dt = e.dataTransfer;
+                if (!dt) return;
+                if (dt.files && dt.files.length > 0) {
+                  void uploadFiles(dt.files, parentDirPath());
+                  return;
+                }
+                const sourcePath = dt.getData("text/plain") || draggedPath();
+                void moveDraggedEntryToDirectory(parentDirPath(), sourcePath);
+              }}
+            >
+              <div class="flex items-center gap-1.5 min-w-0">
+                <FolderUp size={13} class="shrink-0 text-accent" />
+                <span class="truncate">..</span>
+              </div>
+              <div class="text-secondary/60 text-right tabular-nums"></div>
+              <Show when={props.mode === "dialog"}>
+                <div class="text-secondary/60 text-right tabular-nums"></div>
+              </Show>
+            </div>
+          </Show>
+
+          <Show when={viewMode() === "list" && entries().length === 0 && currentPath() === WORKSPACE_ROOT}>
+            <div
+              class={clsx(
+                "grid gap-2 px-2 py-1 italic text-secondary/55",
+                props.mode === "dialog" ? dialogColumnTemplate : panelColumnTemplate,
+                "bg-background/55",
+              )}
+            >
+              <div class="min-w-0 truncate">(empty)</div>
+              <div></div>
+              <Show when={props.mode === "dialog"}>
+                <div></div>
+              </Show>
+            </div>
+          </Show>
+
+          <Show when={viewMode() === "tree" && visibleTreeRows().length === 0}>
+            <div
+              class={clsx(
+                "grid gap-2 px-2 py-1 italic text-secondary/55",
+                props.mode === "dialog" ? dialogColumnTemplate : panelColumnTemplate,
+                "bg-background/55",
+              )}
+            >
+              <div class="min-w-0 truncate">(empty)</div>
+              <div></div>
+              <Show when={props.mode === "dialog"}>
+                <div></div>
+              </Show>
+            </div>
+          </Show>
+
+          <For each={viewMode() === "tree" ? visibleTreeRows() : entries().map((entry, index) => ({ entry, depth: 0, index }))}>
+            {(row, loopIndex) => (
+              <div
+                draggable={editingPath() !== row.entry.path}
+                data-testid={TESTID.filesPanelRow}
+                data-entry-path={row.entry.path}
+                data-entry-name={row.entry.name}
+                data-entry-type={row.entry.type}
+                class={clsx(
+                  "group grid gap-2 px-2 py-1 cursor-pointer",
+                  props.mode === "dialog" ? dialogColumnTemplate : panelColumnTemplate,
+                  loopIndex() % 2 === 0 ? "bg-background/55" : "bg-foreground/15",
+                  selectedPathSet().has(row.entry.path) && "bg-foreground/30",
+                  dragOverDirPath() === row.entry.path && row.entry.type === "dir" && "ring-1 ring-accent/70 bg-foreground!",
+                  "hover:bg-foreground/30",
+                )}
+                onPointerDown={(e) => {
+                  e.stopPropagation();
+                }}
+                onClick={(e) => {
+                  panelRootRef?.focus({ preventScroll: true });
+                  if (editingPath() === row.entry.path) return;
+                  const entryPath = row.entry.path;
+                  const anchorPath = selectionAnchorPath() || selectedPath();
+                  const shiftSelect = e.shiftKey;
+                  const toggleSelect = e.metaKey || e.ctrlKey;
+
+                  if (shiftSelect && anchorPath && indexByPath().has(anchorPath)) {
+                    const start = indexByPath().get(anchorPath)!;
+                    const end = indexByPath().get(entryPath)!;
+                    const lo = Math.min(start, end);
+                    const hi = Math.max(start, end);
+                    const orderedEntries = viewMode() === "tree" ? visibleTreeRows().map((item) => item.entry) : entries();
+                    const rangePaths = orderedEntries.slice(lo, hi + 1).map((item) => item.path);
+                    if (toggleSelect) {
+                      setSelectedPaths((prev) => Array.from(new Set([...prev, ...rangePaths])));
+                    } else {
+                      setSelectedPaths(rangePaths);
+                    }
+                    setSelectedPath(entryPath);
+                    return;
+                  }
+
+                  if (toggleSelect) {
+                    setSelectedPaths((prev) => {
+                      const has = prev.includes(entryPath);
+                      if (has) {
+                        const next = prev.filter((path) => path !== entryPath);
+                        if (selectedPath() === entryPath) setSelectedPath(next[next.length - 1] || null);
+                        return next;
+                      }
+                      return [...prev, entryPath];
+                    });
+                    setSelectedPath(entryPath);
+                    setSelectionAnchorPath(entryPath);
+                    return;
+                  }
+
+                  setSelectedPath(entryPath);
+                  setSelectedPaths([entryPath]);
+                  setSelectionAnchorPath(entryPath);
+                  if (row.entry.type === "file") void previewFile(row.entry.path);
+                }}
+                onDblClick={() => {
+                  void openEntry(row.entry);
+                }}
+                onDragStart={(e) => handleEntryDragStart(row.entry, e, e.currentTarget)}
+                onDragEnd={handleEntryDragEnd}
+                onDragOver={(e) => {
+                  if (row.entry.type !== "dir") return;
+                  e.preventDefault();
+                  setDragOverDirPath(row.entry.path);
+                }}
+                onDragLeave={(e) => {
+                  const related = e.relatedTarget as Node | null;
+                  if (related && (e.currentTarget as HTMLDivElement).contains(related)) return;
+                  if (dragOverDirPath() === row.entry.path) setDragOverDirPath(null);
+                }}
+                onDrop={(e) => {
+                  if (row.entry.type !== "dir") return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setDragOverDirPath(null);
+                  const dt = e.dataTransfer;
+                  if (!dt) return;
+                  if (dt.files && dt.files.length > 0) {
+                    void (async () => {
+                      try {
+                        const files = await Promise.all(
+                          Array.from(dt.files).map(async (file) => ({
+                            name: file.name,
+                            data_base64: await toBase64(file),
+                          })),
+                        );
+                        await kernel.filesystem({ op: "upload", path: row.entry.path, files });
+                        await refresh();
+                      } catch (err) {
+                        setError(err instanceof Error ? err.message : "Failed to upload files");
+                      }
+                    })();
+                    return;
+                  }
+                  const sourcePath = dt.getData("text/plain") || draggedPath();
+                  void moveDraggedEntryToDirectory(row.entry.path, sourcePath);
+                }}
+              >
+                <div class="flex items-center gap-1.5 min-w-0" style={viewMode() === "tree" ? { "padding-left": `${row.depth * 14}px` } : undefined}>
+                  <Show when={props.mode === "dialog" && viewMode() === "tree" && row.entry.type === "dir"}>
+                    <button
+                      class="inline-flex h-5 w-5 items-center justify-center text-secondary/55 hover:text-secondary rounded-sm shrink-0"
+                      title={expandedDirPathSet().has(row.entry.path) ? "Collapse folder" : "Expand folder"}
+                      aria-label={expandedDirPathSet().has(row.entry.path) ? "Collapse folder" : "Expand folder"}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        panelRootRef?.focus({ preventScroll: true });
+                        void openDirectory(row.entry.path);
+                      }}
+                    >
+                      <Show when={expandedDirPathSet().has(row.entry.path)} fallback={<ChevronRight size={13} />}>
+                        <ChevronDown size={13} />
+                      </Show>
+                    </button>
+                  </Show>
+                  <Show
+                    when={row.entry.type === "dir"}
+                    fallback={(() => {
+                      const Icon = getFileIcon(row.entry.name);
+                      return <Icon size={13} class="shrink-0 text-secondary/60" />;
+                    })()}
+                  >
+                    <Show
+                      when={viewMode() === "tree"}
+                      fallback={<FolderOpen size={13} class="shrink-0 text-accent" />}
+                    >
+                      <Show when={expandedDirPathSet().has(row.entry.path)} fallback={<Folder size={13} class="shrink-0 text-accent" />}>
+                        <FolderOpen size={13} class="shrink-0 text-accent" />
+                      </Show>
+                    </Show>
+                  </Show>
+                  <Show
+                    when={editingPath() === row.entry.path}
+                    fallback={
+                      <span
+                        class="truncate"
+                        title={row.entry.name}
+                        onPointerDown={(e) => armHoldRename(row.entry, e)}
+                        onPointerUp={clearHoldRename}
+                        onPointerLeave={clearHoldRename}
+                      >
+                        {row.entry.name}
+                      </span>
+                    }
+                  >
+                    <input
+                      ref={(el) => {
+                        editingInputRef = el;
+                      }}
+                      value={editingName()}
+                      class="min-w-0 w-full px-0 py-0 bg-foreground/40 outline-none border-0 rounded-none"
+                      autofocus
+                      onClick={(e) => e.stopPropagation()}
+                      onInput={(e) => setEditingName(e.currentTarget.value)}
+                      onBlur={() => {
+                        void commitInlineRename(row.entry);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          void commitInlineRename(row.entry);
+                          return;
+                        }
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          cancelInlineRename();
+                        }
+                      }}
+                    />
+                  </Show>
+                </div>
+                <div class={clsx("text-secondary/60 text-right tabular-nums", props.mode === "dialog" && "text-[12px]")}>
+                  <Show
+                    when={row.entry.type === "file"}
+                    fallback={
+                      <Show when={props.mode === "side" && viewMode() === "tree" && row.entry.type === "dir"}>
+                        <div class="flex w-full justify-end items-center">
+                          <button
+                            class="inline-flex h-5 w-5 items-center justify-end p-0 -mr-1 text-secondary/55 hover:text-secondary rounded-sm"
+                            title={expandedDirPathSet().has(row.entry.path) ? "Collapse folder" : "Expand folder"}
+                            aria-label={expandedDirPathSet().has(row.entry.path) ? "Collapse folder" : "Expand folder"}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              panelRootRef?.focus({ preventScroll: true });
+                              void openDirectory(row.entry.path);
+                            }}
+                          >
+                            <Show when={expandedDirPathSet().has(row.entry.path)} fallback={<ArrowRight size={13} class="ml-auto" />}>
+                              <ChevronDown size={13} class="ml-auto" />
+                            </Show>
+                          </button>
+                        </div>
+                      </Show>
+                    }
+                  >
+                    {formatBytes(row.entry.size)}
+                  </Show>
+                </div>
+                <Show when={props.mode === "dialog"}>
+                  <div class="text-secondary/60 text-right tabular-nums text-[12px]">{formatDate(row.entry.mtime)}</div>
+                </Show>
+              </div>
+            )}
+          </For>
+        </div>
+
+        <div class={clsx("bg-foreground/53 px-2 py-1.5 flex items-center gap-1.5", props.mode === "dialog" ? dialogBorderTop : "border-t border-secondary/40")}>
+          <Show
+            when={props.mode === "dialog"}
+            fallback={
+              <>
+                <button class="w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center" title="Create folder" aria-label="Create folder" onClick={() => void createFolder()}>
+                  <Plus size={14} />
+                </button>
+                <Show when={viewMode() === "tree"}>
+                  <button
+                    class={clsx("w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center", !selectedFolderEntry() && "opacity-40 cursor-not-allowed")}
+                    title={isSelectedFolderExpanded() ? "Collapse selected folder (10 levels)" : "Expand selected folder (10 levels)"}
+                    aria-label={isSelectedFolderExpanded() ? "Collapse selected folder (10 levels)" : "Expand selected folder (10 levels)"}
+                    disabled={!selectedFolderEntry()}
+                    onClick={() => void toggleExpandCollapseSelectedFolder()}
+                  >
+                    <Show when={isSelectedFolderExpanded()} fallback={<ArrowDownFromLine size={14} />}>
+                      <ListChevronsDownUp size={14} />
+                    </Show>
+                  </button>
+                </Show>
+                <button class={clsx("w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center", selectedEntries().length !== 1 && "opacity-40 cursor-not-allowed")} title="Rename selected" aria-label="Rename selected" disabled={selectedEntries().length !== 1} onClick={() => { const s = selectedEntry(); if (s) void renameEntry(s); }}>
+                  <Pencil size={14} />
+                </button>
+                <button class={clsx("w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center", selectedEntries().length === 0 && "opacity-40 cursor-not-allowed")} title="Move selected" aria-label="Move selected" disabled={selectedEntries().length === 0} onClick={() => void moveSelectedEntries()}>
+                  <ArrowRightLeft size={14} />
+                </button>
+                <button class={clsx("w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center", selectedEntries().length === 0 && "opacity-40 cursor-not-allowed")} title="Copy selected" aria-label="Copy selected" disabled={selectedEntries().length === 0} onClick={() => void copySelectedEntries()}>
+                  <Copy size={14} />
+                </button>
+                <button class={clsx("w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center", (selectedEntries().length !== 1 || selectedEntry()?.type !== "file") && "opacity-40 cursor-not-allowed")} title="Download selected file" aria-label="Download selected file" disabled={selectedEntries().length !== 1 || selectedEntry()?.type !== "file"} onClick={() => { const s = selectedEntry(); if (s && s.type === "file") void downloadEntry(s); }}>
+                  <Download size={14} />
+                </button>
+                <button class={clsx("w-7 h-7 rounded-sm hover:bg-foreground flex items-center justify-center text-primary", selectedEntries().length === 0 && "opacity-40 cursor-not-allowed")} title={selectedEntries().length > 0 ? `Delete ${selectedEntries().length} selected` : "Select files or folders to delete"} aria-label="Delete selected" disabled={selectedEntries().length === 0} onClick={() => void deleteSelectedEntry()}>
+                  <Trash2 size={14} />
+                </button>
+              </>
+            }
+          >
+            <button class="px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1" onClick={() => void createFolder()}><Plus size={13} /> Folder</button>
+            <Show when={viewMode() === "tree"}>
+              <button
+                class={clsx("px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1", !selectedFolderEntry() && "opacity-40 cursor-not-allowed")}
+                disabled={!selectedFolderEntry()}
+                onClick={() => void toggleExpandCollapseSelectedFolder()}
+                title={isSelectedFolderExpanded() ? "Collapse selected folder (10 levels)" : "Expand selected folder (10 levels)"}
+              >
+                <Show when={isSelectedFolderExpanded()} fallback={<><ArrowDownFromLine size={13} /> Expand</>}>
+                  <><ListChevronsDownUp size={13} /> Collapse</>
+                </Show>
+              </button>
+            </Show>
+            <button class={clsx("px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1", selectedEntries().length !== 1 && "opacity-40 cursor-not-allowed")} disabled={selectedEntries().length !== 1} onClick={() => { const s = selectedEntry(); if (s) void renameEntry(s); }}><Pencil size={13} /> Rename</button>
+            <button class={clsx("px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1", selectedEntries().length === 0 && "opacity-40 cursor-not-allowed")} disabled={selectedEntries().length === 0} onClick={() => void moveSelectedEntries()}><ArrowRightLeft size={13} /> Move</button>
+            <button class={clsx("px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1", selectedEntries().length === 0 && "opacity-40 cursor-not-allowed")} disabled={selectedEntries().length === 0} onClick={() => void copySelectedEntries()}><Copy size={13} /> Copy</button>
+            <button class={clsx("px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1", (selectedEntries().length !== 1 || selectedEntry()?.type !== "file") && "opacity-40 cursor-not-allowed")} disabled={selectedEntries().length !== 1 || selectedEntry()?.type !== "file"} onClick={() => { const s = selectedEntry(); if (s && s.type === "file") void downloadEntry(s); }}><Download size={13} /> Download</button>
+            <button class={clsx("px-2 py-1 rounded-sm hover:bg-foreground flex items-center gap-1 text-primary", selectedEntries().length === 0 && "opacity-40 cursor-not-allowed")} disabled={selectedEntries().length === 0} onClick={() => void deleteSelectedEntry()} title={selectedEntries().length > 0 ? `Delete ${selectedEntries().length} selected` : "Select files or folders to delete"}><Trash2 size={13} /> Delete</button>
+          </Show>
+        </div>
+      </div>
+
+      <div class="min-h-4 text-[11px] text-secondary/60" aria-live="polite">
+        <Show when={loading()}>
+          <span>Loading filesystem...</span>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default FileWorkspacePanel;

--- a/src/components/Notebook.tsx
+++ b/src/components/Notebook.tsx
@@ -6,17 +6,30 @@ import { isBuiltinNotebook, getBuiltinNotebook } from "../lib/notebooks";
 import { isBuiltinTheme, getBuiltinTheme } from "../lib/themes";
 import CodeCell from "./CodeCell";
 import MarkdownCell from "./MarkdownCell";
-import { Plus, Code, FileText, ChevronDown, StopCircle, RotateCw, Save, FolderOpen, Download, Undo2, Redo2, X, Eye, Play, Trash2, Keyboard, BookOpen, Activity, EyeOff, Palette } from "lucide-solid";
+import { Plus, Code, FileText, ChevronDown, StopCircle, RotateCw, Save, FolderOpen, Download, Undo2, Redo2, X, Eye, Play, Trash2, Keyboard, BookOpen, Activity, EyeOff, Palette, PanelLeft } from "lucide-solid";
 import { kernel } from "../lib/pyodide";
 import Dropdown, { DropdownItem, DropdownDivider } from "./ui/Dropdown";
 import { sessionManager } from "../lib/session";
 import { codeVisibility, setVisibilitySettings, resetUserOverride, getSessionState, restoreSessionState, setOnCellOverrideChange, applyDocumentSettings, shouldLoadMetadataSettings, shouldAutoRun, shouldAutoRunOnRefresh, type CodeVisibilitySettings } from "../lib/codeVisibility";
 import { currentTheme, updateTheme, saveThemeAppWide, loadAppTheme, defaultTheme } from "../lib/theme";
 import { TESTID } from "../lib/testids";
+import FileWorkspacePanel from "./FileWorkspacePanel";
 
 const PerformanceMonitor = lazy(() => import("./PerformanceMonitor"));
 const CodeVisibilityDialog = lazy(() => import("./CodeVisibilityDialog"));
 const ThemeDialog = lazy(() => import("./ThemeDialog"));
+
+type FilesPanelViewMode = "list" | "tree";
+const FILES_PANEL_VIEW_MODE_STORAGE_KEY = "pynote-files-panel-view-mode";
+
+const loadPersistedFilesPanelViewMode = (): FilesPanelViewMode => {
+  try {
+    const stored = localStorage.getItem(FILES_PANEL_VIEW_MODE_STORAGE_KEY);
+    return stored === "tree" ? "tree" : "list";
+  } catch {
+    return "list";
+  }
+};
 
 // Strip "no-op" empty-string overrides from a theme before writing it to a
 // notebook's metadata, so the saved .ipynb isn't bloated with unused fields.
@@ -49,6 +62,7 @@ const SHORTCUTS = {
     { label: "Save As", keys: "Ctrl + Shift + S" },
     { label: "Export .ipynb", keys: "Ctrl + E" },
     { label: "Toggle Shortcuts", keys: "Ctrl + \\" },
+    { label: "Toggle Files & Data", keys: "Ctrl + ." },
     { label: "Presentation Mode", keys: "Alt + P" },
     { label: "Theme Configuration", keys: "Alt + T" },
     { label: "Code Visibility", keys: "Alt + V" },
@@ -104,12 +118,12 @@ const SideShortcuts: Component<{ activeId: string | null; isEditing: boolean; on
   };
 
   return (
-     <div class="fixed left-[calc(50%+28rem)] px-2 top-32 w-72 max-w-[20rem] hidden 2xl:flex flex-col text-secondary/60 transition-opacity duration-300 group z-[300000]">
-        <button 
+     <div class="fixed left-[calc(50%+28rem)] px-2 top-32 w-[calc(50%-32rem)] max-w-[20rem] hidden 2xl:flex flex-col text-secondary/60 transition-opacity duration-300 group z-[300000]">
+          <button
             onClick={props.onClose}
-            class="self-end -mb-5 p-1.5 rounded-lg hover:bg-foreground text-secondary/40 hover:text-secondary opacity-0 group-hover:opacity-100 transition-all duration-200 cursor-pointer z-300002"
+            class="self-end -mb-5 translate-y-[2px] translate-x-1.5 p-1.5 rounded-lg hover:bg-foreground text-secondary/40 hover:text-secondary opacity-0 group-hover:opacity-100 transition-all duration-200 cursor-pointer z-300002"
             title="Hide Shortcuts"
-        >
+          >
             <X size={16} />
         </button>
 
@@ -145,6 +159,24 @@ const SideShortcuts: Component<{ activeId: string | null; isEditing: boolean; on
         </Show>
         </div>
      </div>
+  );
+};
+
+const SideLeftPanel: Component<{ onClose: () => void; viewMode: FilesPanelViewMode; onViewModeChange: (nextMode: FilesPanelViewMode) => void }> = (props) => {
+  return (
+    <div class="fixed right-[calc(50%+28rem)] px-2 top-32 w-[calc(50%-32rem)] max-w-[20rem] hidden 2xl:flex flex-col text-secondary/60 transition-opacity duration-300 group z-300000" data-testid={TESTID.filesSidePanel}>
+      <button
+        onClick={props.onClose}
+        class="self-end -mb-5 translate-y-[2px] translate-x-1.5 p-1.5 rounded-lg hover:bg-foreground text-secondary/40 hover:text-secondary opacity-0 group-hover:opacity-100 transition-all duration-200 cursor-pointer z-300002"
+        title="Hide Left Panel"
+      >
+        <X size={16} />
+      </button>
+
+      <div class="overflow-x-hidden">
+        <FileWorkspacePanel mode="side" viewMode={props.viewMode} onViewModeChange={props.onViewModeChange} />
+      </div>
+    </div>
   );
 };
 
@@ -269,10 +301,21 @@ const Notebook: Component = () => {
   // Signal for showing the Esc hint in presentation mode
   const [showEscHint, setShowEscHint] = createSignal(false);
   const [showShortcuts, setShowShortcuts] = createSignal(false);
+  const [showLeftPanel, setShowLeftPanel] = createSignal(false);
   const [showPerformance, setShowPerformance] = createSignal(false);
   const [showCodeVisibility, setShowCodeVisibility] = createSignal(false);
   const [showThemeDialog, setShowThemeDialog] = createSignal(false);
   const [sessionHasTheme, setSessionHasTheme] = createSignal(false);
+  const [filesPanelViewMode, setFilesPanelViewMode] = createSignal<FilesPanelViewMode>(loadPersistedFilesPanelViewMode());
+
+  const setAndPersistFilesPanelViewMode = (nextMode: FilesPanelViewMode) => {
+    setFilesPanelViewMode(nextMode);
+    try {
+      localStorage.setItem(FILES_PANEL_VIEW_MODE_STORAGE_KEY, nextMode);
+    } catch {
+      // Ignore storage write failures.
+    }
+  };
   // Original theme/codeview from the loaded document metadata.
   // Preserved on save when saveToExport is off, so user UI changes
   // don't accidentally overwrite the file's embedded metadata.
@@ -645,6 +688,9 @@ const Notebook: Component = () => {
 
         e.preventDefault();
         setShowShortcuts(!showShortcuts());
+      } else if ((e.ctrlKey || e.metaKey) && e.key === ".") {
+        e.preventDefault();
+        setShowLeftPanel(!showLeftPanel());
       } else if (e.altKey && e.key === "p") {
         e.preventDefault();
         actions.setPresentationMode(!notebookStore.presentationMode);
@@ -1581,6 +1627,9 @@ const Notebook: Component = () => {
                    }}>
                        <div class="flex items-center gap-2"><BookOpen size={18} /> Tutorial</div>
                    </DropdownItem>
+                       <DropdownItem onClick={() => setShowLeftPanel(!showLeftPanel())} shortcut="Ctrl+.">
+                         <div class="flex items-center gap-2"><PanelLeft size={18} /> Files & Data</div>
+                     </DropdownItem>
                    <DropdownItem onClick={() => setShowShortcuts(!showShortcuts())} shortcut="Ctrl+\">
                        <div class="flex items-center gap-2"><Keyboard size={18} /> Shortcuts</div>
                    </DropdownItem>
@@ -1817,6 +1866,9 @@ const Notebook: Component = () => {
                          window.open(url, '_blank');
                      }}>
                          <div class="flex items-center gap-2"><BookOpen size={18} /> Tutorial</div>
+                     </DropdownItem>
+                     <DropdownItem onClick={() => setShowLeftPanel(true)} shortcut="Ctrl+.">
+                       <div class="flex items-center gap-2"><PanelLeft size={18} /> Files & Data</div>
                      </DropdownItem>
                      <DropdownItem onClick={() => setShowShortcuts(true)} shortcut="Ctrl+\">
                          <div class="flex items-center gap-2"><Keyboard size={18} /> Shortcuts</div>
@@ -2102,6 +2154,31 @@ const Notebook: Component = () => {
             isEditing={!!notebookStore.activeCellId && !!notebookStore.cells.find(c => c.id === notebookStore.activeCellId)?.isEditing} 
             onClose={() => setShowShortcuts(false)}
           />
+       </Show>
+
+       {/* Left Panel Modal */}
+       <Show when={showLeftPanel()}>
+         <div class="fixed inset-0 z-300000 flex items-center justify-center p-4 bg-background/80 backdrop-blur-sm 2xl:hidden" onClick={() => setShowLeftPanel(false)} data-testid={TESTID.filesDialog}>
+           <div class="bg-background ui-border ui-font rounded-sm shadow-xl max-w-3xl w-full max-h-[85vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
+             <div class="flex items-center justify-between p-4 [border-bottom-width:var(--ui-divider-width,1px)] ui-divider shrink-0">
+               <h2 class="text-lg font-bold flex items-center gap-2"><PanelLeft /> Files & Data</h2>
+               <button onClick={() => setShowLeftPanel(false)} class="p-1 hover:bg-foreground rounded-sm">
+                 <X size={20} />
+               </button>
+             </div>
+             <div class="p-4 overflow-y-auto flex-1">
+               <FileWorkspacePanel mode="dialog" viewMode={filesPanelViewMode()} onViewModeChange={setAndPersistFilesPanelViewMode} />
+             </div>
+             <div class="p-4 [border-top-width:var(--ui-divider-width,1px)] ui-divider text-center text-xs text-secondary/50 shrink-0">
+               Click anywhere outside to close
+             </div>
+           </div>
+         </div>
+       </Show>
+
+       {/* Left Panel (Visible on 2xl screens) */}
+       <Show when={showLeftPanel() && !notebookStore.presentationMode}>
+         <SideLeftPanel onClose={() => setShowLeftPanel(false)} viewMode={filesPanelViewMode()} onViewModeChange={setAndPersistFilesPanelViewMode} />
        </Show>
 
        {/* Performance Monitor */}

--- a/src/components/ui-renderer/Upload.tsx
+++ b/src/components/ui-renderer/Upload.tsx
@@ -5,6 +5,7 @@ import { kernel } from "../../lib/pyodide";
 import { useFormContext } from "./FormContext";
 import { resolveColor, resolveBorder, resolveBackground } from "./colorUtils";
 import { CloudUpload, CircleCheckBig, CloudAlert, Circle, X, Loader } from "lucide-solid";
+import { TESTID } from "../../lib/testids";
 
 // --- Types ---
 
@@ -28,6 +29,7 @@ interface UploadProps {
     accept?: string | null;
     max_size?: number | null;
     label?: string | null;
+    dir?: string | null;
     color?: string | null;
     size?: "xs" | "sm" | "md" | "lg" | "xl" | null;
     disabled?: boolean;
@@ -407,6 +409,9 @@ const Upload: Component<UploadProps> = (p) => {
           el.addEventListener("dragleave", handleDragLeave);
           el.addEventListener("drop", handleDrop);
         }}
+        data-testid={TESTID.uploadComponent}
+        data-component-id={componentId}
+        data-label={label()}
         class={`${uploadClass} rounded-sm cursor-pointer select-none font-mono flex-col ${sizeConfig().paddingClass} ${borderClass()} ${hidden() ? "hidden" : "flex"} ${allProps().height == null ? "min-h-[120px]" : ""} ${isDragOver() ? "drag-over" : ""}`}
         style={{
           ...componentStyles(),

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@ html {
 }
 
 body {
-  background-color: transparent;
+    background-color: var(--background);
   color: inherit;
   font-family: var(--font-mono);
   font-weight: var(--font-weight-base, normal);

--- a/src/lib/notebooks/tutorials/tutorial-ui-part3.ts
+++ b/src/lib/notebooks/tutorials/tutorial-ui-part3.ts
@@ -254,82 +254,96 @@ The \`Upload\` component provides a **drag & drop** file upload area. Files can 
     {
         id: "tut-ui-upload-standalone",
         type: "markdown",
-        content: "### Standalone Upload (Immediate Mode)\n\nWhen used outside a Form, files are sent to Python immediately after dropping. Access uploaded files via `uploader.files` — a dictionary mapping filenames to their raw bytes."
+        content: "### Standalone Upload (Immediate Mode)\n\nWhen used outside a Form, files are sent to Python immediately after dropping. Each successful upload is also written into `/workspace`, so it appears in Files and Data and can be opened by code that reads from disk. Access uploaded bytes via `uploader.files` and workspace locations via `uploader.workspace_paths`. Use `dir` to target a subdirectory under `/workspace`, but create that directory in Python first if it does not already exist. Invalid or missing destinations surface an upload error."
     },
     {
         id: "tut-demo-upload-standalone",
         type: "code",
-        content: `from pynote_ui import *
-
-# --- Standalone Upload (immediate mode) ---
-uploader = Upload(label="Drop files here", width="100%")
-
-status_text = Text(content="No files uploaded yet.", border=False)
-
-def on_upload(data):
-    if not uploader.files:
-        status_text.content = "No files uploaded yet."
-        return
-    nl = chr(10)
-    lines = []
-    for name, raw in uploader.files.items():
-        try:
-            text = raw.decode("utf-8")
-        except Exception:
-            text = repr(raw[:100])
-        preview = text[:300] + ("..." if len(text) > 300 else "")
-        lines.append(f"**{name}** ({len(raw)} bytes)")
-        lines.append(preview)
-    status_text.content = (nl * 2).join(lines)
-
-uploader.on_update(on_upload)
-
-Group([
-    Text(content="Standalone Upload (immediate)", border=False, size="lg"),
-    uploader,
-    status_text
-], gap=3, border=True, label="Immediate Mode")`
+        content: [
+            "from pynote_ui import *",
+            "from pathlib import Path",
+            "",
+            "Path(\"/workspace/data\").mkdir(parents=True, exist_ok=True)",
+            "",
+            "# --- Standalone Upload (immediate mode) ---",
+            "uploader = Upload(label=\"Drop files here\", dir=\"data\", width=\"100%\")",
+            "",
+            "status_text = Text(content=\"No files uploaded yet.\", border=False)",
+            "",
+            "def on_upload(data):",
+            "    if not uploader.files:",
+            "        status_text.content = \"No files uploaded yet.\"",
+            "        return",
+            "    nl = chr(10)",
+            "    lines = []",
+            "    for name, raw in uploader.files.items():",
+            "        workspace_path = uploader.workspace_paths[name]",
+            "        try:",
+            "            text = raw.decode(\"utf-8\")",
+            "        except Exception:",
+            "            text = repr(raw[:100])",
+            "        preview = text[:300] + (\"...\" if len(text) > 300 else \"\")",
+            "        lines.append(f\"**{name}** ({len(raw)} bytes)\")",
+            "        lines.append(f\"Saved to: {workspace_path}\")",
+            "        lines.append(preview)",
+            "    status_text.content = (nl * 2).join(lines)",
+            "",
+            "uploader.on_update(on_upload)",
+            "",
+            "Group([",
+            "    Text(content=\"Standalone Upload (immediate)\", border=False, size=\"lg\"),",
+            "    uploader,",
+            "    status_text",
+            "], gap=3, border=True, label=\"Immediate Mode\")",
+        ].join("\n")
     },
 
     // --- Upload inside Form ---
     {
         id: "tut-ui-upload-form",
         type: "markdown",
-        content: "### Upload inside a Form (Deferred Mode)\n\nWhen placed inside a `Form`, files are **not sent to Python** until the form is submitted. This lets users add/remove files before committing."
+        content: "### Upload inside a Form (Deferred Mode)\n\nWhen placed inside a `Form`, files are **not sent to Python** until the form is submitted. After submit, successful files become available both as raw bytes in `form_upload.files` and as real files in `/workspace`. Use `dir` when you want those saved files to land in a specific directory under `/workspace`, and create that directory in Python first if needed."
     },
     {
         id: "tut-demo-upload-form",
         type: "code",
-        content: `from pynote_ui import *
-
-# --- Upload inside a Form (deferred mode) ---
-form_upload = Upload(label="Attach files", width="100%")
-submit_btn = Button(label="Submit Form", button_type="submit", color="primary", width="100%")
-form_status = Text(content="Add files and click Submit.", border=False)
-
-def on_submit(data):
-    if not form_upload.files:
-        form_status.content = "Form submitted with no files."
-        return
-    nl = chr(10)
-    lines = []
-    for name, raw in form_upload.files.items():
-        try:
-            text = raw.decode("utf-8")
-        except Exception:
-            text = repr(raw[:100])
-        preview = text[:300] + ("..." if len(text) > 300 else "")
-        lines.append(f"**{name}** ({len(raw)} bytes)")
-        lines.append(preview)
-    form_status.content = (nl * 2).join(lines)
-
-submit_btn.on_update(on_submit)
-
-Form([
-    form_upload,
-    submit_btn,
-    form_status
-], label="Deferred Upload (Form)", border=True, gap=3)`
+        content: [
+            "from pynote_ui import *",
+            "from pathlib import Path",
+            "",
+            "Path(\"/workspace/incoming\").mkdir(parents=True, exist_ok=True)",
+            "",
+            "# --- Upload inside a Form (deferred mode) ---",
+            "form_upload = Upload(label=\"Attach files\", dir=\"incoming\", width=\"100%\")",
+            "submit_btn = Button(label=\"Submit Form\", button_type=\"submit\", color=\"primary\", width=\"100%\")",
+            "form_status = Text(content=\"Add files and click Submit.\", border=False)",
+            "",
+            "def on_submit(data):",
+            "    if not form_upload.files:",
+            "        form_status.content = \"Form submitted with no files.\"",
+            "        return",
+            "    nl = chr(10)",
+            "    lines = []",
+            "    for name, raw in form_upload.files.items():",
+            "        workspace_path = form_upload.workspace_paths[name]",
+            "        try:",
+            "            text = raw.decode(\"utf-8\")",
+            "        except Exception:",
+            "            text = repr(raw[:100])",
+            "        preview = text[:300] + (\"...\" if len(text) > 300 else \"\")",
+            "        lines.append(f\"**{name}** ({len(raw)} bytes)\")",
+            "        lines.append(f\"Saved to: {workspace_path}\")",
+            "        lines.append(preview)",
+            "    form_status.content = (nl * 2).join(lines)",
+            "",
+            "submit_btn.on_update(on_submit)",
+            "",
+            "Form([",
+            "    form_upload,",
+            "    submit_btn,",
+            "    form_status",
+            "], label=\"Deferred Upload (Form)\", border=True, gap=3)",
+        ].join("\n")
     },
 
     // ============================================================================

--- a/src/lib/pyodide.ts
+++ b/src/lib/pyodide.ts
@@ -14,6 +14,17 @@ export interface ExecutionResult {
   executionKernelId?: string;
 }
 
+export type KernelFsRequest =
+  | { op: "list"; path?: string }
+  | { op: "mkdir"; path: string }
+  | { op: "upload"; path: string; files: Array<{ name: string; data_base64: string }> }
+  | { op: "delete"; path: string }
+  | { op: "rename"; path: string; newName: string }
+  | { op: "move"; sourcePath: string; destinationDir: string; onConflict?: "error" | "replace" | "keep_both" | "skip" }
+  | { op: "copy"; sourcePath: string; destinationDir: string; onConflict?: "error" | "replace" | "keep_both" | "skip" }
+  | { op: "download"; path: string }
+  | { op: "read_text"; path: string; maxBytes?: number };
+
 class Kernel {
   private worker: Worker | null = null;
   private listeners: Map<string, (msg: any) => void> = new Map();
@@ -195,6 +206,27 @@ class Kernel {
         }
       });
       this.worker!.postMessage({ type: "inspect", id, code, offset });
+    });
+  }
+
+  filesystem<T = unknown>(request: KernelFsRequest): Promise<T> {
+    if (!this.worker || this.status === "loading") {
+      return Promise.reject(new Error("Kernel not ready"));
+    }
+
+    return new Promise((resolve, reject) => {
+      const id = `fs_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+      this.listeners.set(id, (msg) => {
+        if (msg.type === "filesystem_result") {
+          this.listeners.delete(id);
+          if (msg.ok) {
+            resolve(msg.result as T);
+          } else {
+            reject(new Error(msg.error || "Filesystem request failed"));
+          }
+        }
+      });
+      this.worker!.postMessage({ type: "filesystem", id, request });
     });
   }
 

--- a/src/lib/pyodide.worker.ts
+++ b/src/lib/pyodide.worker.ts
@@ -2,6 +2,335 @@
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.mjs";
 
 let pyodide: any = null;
+const WORKSPACE_ROOT = "/workspace";
+let workspacePersistenceEnabled = false;
+
+const normalizePath = (inputPath: string): string => {
+    const source = inputPath.trim();
+    const segments = source.replace(/\\/g, "/").split("/");
+    const out: string[] = [];
+    for (const segment of segments) {
+        if (!segment || segment === ".") continue;
+        if (segment === "..") {
+            if (out.length > 0) out.pop();
+            continue;
+        }
+        out.push(segment);
+    }
+    return `/${out.join("/")}`;
+};
+
+const normalizeWorkspacePath = (inputPath?: string): string => {
+    const raw = inputPath && inputPath.trim() ? inputPath : WORKSPACE_ROOT;
+    const normalized = raw.startsWith("/") ? normalizePath(raw) : normalizePath(`${WORKSPACE_ROOT}/${raw}`);
+    if (normalized === WORKSPACE_ROOT) return normalized;
+    if (!normalized.startsWith(`${WORKSPACE_ROOT}/`)) {
+        throw new Error("Path must stay inside /workspace");
+    }
+    return normalized;
+};
+
+const pathExists = (path: string): boolean => {
+    const analyzed = pyodide.FS.analyzePath(path);
+    return !!analyzed.exists;
+};
+
+const isDirectory = (path: string): boolean => {
+    const stat = pyodide.FS.stat(path);
+    return pyodide.FS.isDir(stat.mode);
+};
+
+const basename = (path: string): string => {
+    const parts = path.split("/").filter(Boolean);
+    return parts[parts.length - 1] || "";
+};
+
+const splitNameExtension = (name: string): { stem: string; extension: string } => {
+    const dotIndex = name.lastIndexOf(".");
+    if (dotIndex <= 0) {
+        return { stem: name, extension: "" };
+    }
+    return {
+        stem: name.slice(0, dotIndex),
+        extension: name.slice(dotIndex),
+    };
+};
+
+const copyNameAtIndex = (name: string, index: number): string => {
+    const { stem, extension } = splitNameExtension(name);
+    if (index <= 1) return `${stem} (copy)${extension}`;
+    return `${stem} (copy ${index})${extension}`;
+};
+
+const resolveKeepBothPath = (destinationDir: string, name: string): string => {
+    for (let index = 1; index < 10000; index += 1) {
+        const candidate = joinPath(destinationDir, copyNameAtIndex(name, index));
+        if (!pathExists(candidate)) return candidate;
+    }
+    throw new Error("Could not generate copy name");
+};
+
+const joinPath = (dir: string, name: string): string => {
+    return normalizePath(`${dir}/${name}`);
+};
+
+const syncWorkspaceFs = async (populate: boolean): Promise<void> => {
+    if (!workspacePersistenceEnabled) return;
+    await new Promise<void>((resolve, reject) => {
+        pyodide.FS.syncfs(populate, (err: unknown) => {
+            if (err) reject(err);
+            else resolve();
+        });
+    });
+};
+
+const setupWorkspaceFs = async (): Promise<void> => {
+    try {
+        pyodide.FS.mkdirTree(WORKSPACE_ROOT);
+    } catch {
+        // Already exists.
+    }
+
+    try {
+        pyodide.FS.mount(pyodide.FS.filesystems.IDBFS, {}, WORKSPACE_ROOT);
+        workspacePersistenceEnabled = true;
+        await syncWorkspaceFs(true);
+    } catch {
+        workspacePersistenceEnabled = false;
+    }
+};
+
+const deleteRecursive = (target: string) => {
+    if (!pathExists(target)) return;
+    if (isDirectory(target)) {
+        const children: string[] = pyodide.FS.readdir(target).filter((name: string) => name !== "." && name !== "..");
+        for (const child of children) {
+            deleteRecursive(joinPath(target, child));
+        }
+        pyodide.FS.rmdir(target);
+        return;
+    }
+    pyodide.FS.unlink(target);
+};
+
+const copyRecursive = (sourcePath: string, destinationPath: string) => {
+    if (isDirectory(sourcePath)) {
+        pyodide.FS.mkdirTree(destinationPath);
+        const children: string[] = pyodide.FS.readdir(sourcePath).filter((name: string) => name !== "." && name !== "..");
+        for (const child of children) {
+            copyRecursive(joinPath(sourcePath, child), joinPath(destinationPath, child));
+        }
+        return;
+    }
+    const data = pyodide.FS.readFile(sourcePath, { encoding: "binary" });
+    pyodide.FS.writeFile(destinationPath, data, { encoding: "binary" });
+};
+
+const decodeBase64ToBytes = (base64: string): Uint8Array => {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+};
+
+const encodeBytesToBase64 = (bytes: Uint8Array): string => {
+    const chunk = 0x8000;
+    let binary = "";
+    for (let i = 0; i < bytes.length; i += chunk) {
+        const view = bytes.subarray(i, i + chunk);
+        binary += String.fromCharCode(...view);
+    }
+    return btoa(binary);
+};
+
+const guessMime = (name: string): string => {
+    const lower = name.toLowerCase();
+    if (lower.endsWith(".csv")) return "text/csv";
+    if (lower.endsWith(".json")) return "application/json";
+    if (lower.endsWith(".txt") || lower.endsWith(".md") || lower.endsWith(".py")) return "text/plain";
+    if (lower.endsWith(".png")) return "image/png";
+    if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+    if (lower.endsWith(".gif")) return "image/gif";
+    return "application/octet-stream";
+};
+
+const listDirectory = (path: string) => {
+    const names: string[] = pyodide.FS.readdir(path).filter((name: string) => name !== "." && name !== "..");
+    const entries = names.map((name) => {
+        const fullPath = joinPath(path, name);
+        const stat = pyodide.FS.stat(fullPath);
+        const dir = pyodide.FS.isDir(stat.mode);
+        return {
+            name,
+            path: fullPath,
+            type: dir ? "dir" : "file",
+            size: dir ? 0 : Number(stat.size || 0),
+            mtime: Number(stat.mtime || 0),
+        };
+    });
+    entries.sort((a, b) => {
+        if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+        return a.name.localeCompare(b.name);
+    });
+    return entries;
+};
+
+const handleFilesystemRequest = async (request: any) => {
+    const op = request?.op;
+
+    if (op === "list") {
+        const path = normalizeWorkspacePath(request.path);
+        if (!pathExists(path) || !isDirectory(path)) {
+            throw new Error("Directory not found");
+        }
+        return {
+            path,
+            entries: listDirectory(path),
+            persistent: workspacePersistenceEnabled,
+        };
+    }
+
+    if (op === "mkdir") {
+        const path = normalizeWorkspacePath(request.path);
+        pyodide.FS.mkdirTree(path);
+        await syncWorkspaceFs(false);
+        return { ok: true };
+    }
+
+    if (op === "upload") {
+        const targetDir = normalizeWorkspacePath(request.path);
+        pyodide.FS.mkdirTree(targetDir);
+        const files = Array.isArray(request.files) ? request.files : [];
+        for (const file of files) {
+            if (!file?.name || !file?.data_base64) continue;
+            const targetPath = normalizeWorkspacePath(`${targetDir}/${file.name}`);
+            const bytes = decodeBase64ToBytes(file.data_base64);
+            pyodide.FS.writeFile(targetPath, bytes, { encoding: "binary" });
+        }
+        await syncWorkspaceFs(false);
+        return { ok: true, count: files.length };
+    }
+
+    if (op === "delete") {
+        const path = normalizeWorkspacePath(request.path);
+        if (path === WORKSPACE_ROOT) {
+            throw new Error("Cannot delete /workspace root");
+        }
+        deleteRecursive(path);
+        await syncWorkspaceFs(false);
+        return { ok: true };
+    }
+
+    if (op === "rename") {
+        const path = normalizeWorkspacePath(request.path);
+        if (path === WORKSPACE_ROOT) {
+            throw new Error("Cannot rename /workspace root");
+        }
+        const newName = String(request.newName || "").trim();
+        if (!newName || newName.includes("/")) {
+            throw new Error("Invalid name");
+        }
+        const destination = normalizeWorkspacePath(`${parentPath(path)}/${newName}`);
+        if (pathExists(destination)) {
+            throw new Error("Target already exists");
+        }
+        pyodide.FS.rename(path, destination);
+        await syncWorkspaceFs(false);
+        return { ok: true, path: destination };
+    }
+
+    if (op === "move") {
+        const sourcePath = normalizeWorkspacePath(request.sourcePath);
+        const destinationDir = normalizeWorkspacePath(request.destinationDir);
+        const onConflict = String(request.onConflict || "error");
+        if (!pathExists(destinationDir) || !isDirectory(destinationDir)) {
+            throw new Error("Destination directory does not exist");
+        }
+        let destinationPath = normalizeWorkspacePath(`${destinationDir}/${basename(sourcePath)}`);
+        if (destinationPath === sourcePath) {
+            return { ok: true, path: sourcePath, skipped: true };
+        }
+        if (pathExists(destinationPath)) {
+            if (onConflict === "skip") {
+                return { ok: true, path: sourcePath, skipped: true };
+            }
+            if (onConflict === "replace") {
+                deleteRecursive(destinationPath);
+            } else if (onConflict === "keep_both") {
+                destinationPath = resolveKeepBothPath(destinationDir, basename(sourcePath));
+            } else {
+                throw new Error("Target already exists");
+            }
+        }
+        pyodide.FS.rename(sourcePath, destinationPath);
+        await syncWorkspaceFs(false);
+        return { ok: true, path: destinationPath };
+    }
+
+    if (op === "copy") {
+        const sourcePath = normalizeWorkspacePath(request.sourcePath);
+        const destinationDir = normalizeWorkspacePath(request.destinationDir);
+        const onConflict = String(request.onConflict || "error");
+        if (!pathExists(destinationDir) || !isDirectory(destinationDir)) {
+            throw new Error("Destination directory does not exist");
+        }
+        let destinationPath = normalizeWorkspacePath(`${destinationDir}/${basename(sourcePath)}`);
+        if (pathExists(destinationPath)) {
+            if (onConflict === "skip") {
+                return { ok: true, path: destinationPath, skipped: true };
+            }
+            if (onConflict === "replace") {
+                if (destinationPath === sourcePath) {
+                    throw new Error("Cannot replace source with itself");
+                }
+                deleteRecursive(destinationPath);
+            } else if (onConflict === "keep_both") {
+                destinationPath = resolveKeepBothPath(destinationDir, basename(sourcePath));
+            } else {
+                throw new Error("Target already exists");
+            }
+        }
+        copyRecursive(sourcePath, destinationPath);
+        await syncWorkspaceFs(false);
+        return { ok: true, path: destinationPath };
+    }
+
+    if (op === "read_text") {
+        const path = normalizeWorkspacePath(request.path);
+        if (!pathExists(path) || isDirectory(path)) {
+            throw new Error("File not found");
+        }
+        const maxBytes = typeof request.maxBytes === "number" ? request.maxBytes : 8192;
+        const data: Uint8Array = pyodide.FS.readFile(path, { encoding: "binary" });
+        const truncated = data.byteLength > maxBytes;
+        const slice = truncated ? data.subarray(0, maxBytes) : data;
+        const text = new TextDecoder("utf-8").decode(slice);
+        return { text, truncated };
+    }
+
+    if (op === "download") {
+        const path = normalizeWorkspacePath(request.path);
+        if (!pathExists(path) || isDirectory(path)) {
+            throw new Error("File not found");
+        }
+        const bytes: Uint8Array = pyodide.FS.readFile(path, { encoding: "binary" });
+        return {
+            name: basename(path),
+            mime: guessMime(path),
+            data_base64: encodeBytesToBase64(bytes),
+        };
+    }
+
+    throw new Error("Unsupported filesystem operation");
+};
+
+const parentPath = (path: string): string => {
+    const parts = path.split("/").filter(Boolean);
+    if (parts.length <= 1) return WORKSPACE_ROOT;
+    return `/${parts.slice(0, -1).join("/")}`;
+};
 
 const INIT_CODE = `
 import sys
@@ -1419,14 +1748,15 @@ class Checkbox(UIElement):
         return self
 
 class Upload(UIElement):
-    def __init__(self, accept=None, max_size=None, label="Upload", color=None, size=None,
+    def __init__(self, accept=None, max_size=None, label="Upload", dir=None, color=None, size=None,
                  disabled=False, width=None, height=None, grow=None, shrink=None,
                  force_dimensions=False, border=True, background=True, hidden=False):
         self._files = {}
+        self._workspace_paths = {}
         self._disabled = disabled
         self._size = size
         super().__init__(
-            accept=accept, max_size=max_size, label=label, color=color, size=size,
+            accept=accept, max_size=max_size, label=label, dir=dir, color=color, size=size,
             disabled=disabled, width=width, height=height, grow=grow, shrink=shrink,
             force_dimensions=force_dimensions, border=border, background=background, hidden=hidden
         )
@@ -1434,6 +1764,10 @@ class Upload(UIElement):
     @property
     def files(self):
         return dict(self._files)
+
+    @property
+    def workspace_paths(self):
+        return dict(self._workspace_paths)
 
     @property
     def disabled(self):
@@ -1452,6 +1786,58 @@ class Upload(UIElement):
     def size(self, new_size):
         self._size = new_size
         self.send_update(size=new_size)
+
+    def _safe_workspace_name(self, name):
+        name = str(name or "unknown").replace("\\\\", "/").split("/")[-1].strip()
+        return name or "unknown"
+
+    def _workspace_dir(self):
+        from pathlib import Path
+
+        raw = str(self.props.get("dir") or "/workspace").strip().replace("\\\\", "/")
+        if not raw:
+            raw = "/workspace"
+        if not raw.startswith("/"):
+            raw = f"/workspace/{raw}"
+
+        parts = []
+        for segment in raw.split("/"):
+            if not segment or segment == ".":
+                continue
+            if segment == "..":
+                if parts:
+                    parts.pop()
+                continue
+            parts.append(segment)
+
+        normalized = "/" + "/".join(parts)
+        if normalized != "/workspace" and not normalized.startswith("/workspace/"):
+            raise ValueError("Upload destination must stay inside /workspace")
+
+        path = Path(normalized)
+        if not path.exists() or not path.is_dir():
+            raise FileNotFoundError(f"Upload destination does not exist: {normalized}")
+        return path
+
+    def _workspace_path_for(self, key):
+        safe_name = self._safe_workspace_name(key)
+        return self._workspace_dir() / safe_name
+
+    def _persist_to_workspace(self, key, raw):
+        path = self._workspace_path_for(key)
+        path.write_bytes(raw)
+        self._workspace_paths[key] = str(path)
+
+    def _remove_from_workspace(self, key):
+        from pathlib import Path
+
+        path_str = self._workspace_paths.pop(key, None)
+        if not path_str:
+            path_str = str(self._workspace_path_for(key))
+
+        path = Path(path_str)
+        if path.exists() and path.is_file():
+            path.unlink()
 
     def handle_interaction(self, data):
         import base64
@@ -1473,6 +1859,7 @@ class Upload(UIElement):
                         status[key] = f"error:File exceeds max size ({max_size} bytes)"
                     else:
                         self._files[key] = raw
+                        self._persist_to_workspace(key, raw)
                         status[key] = "success"
                 except Exception as e:
                     status[key] = f"error:{e}"
@@ -1482,6 +1869,7 @@ class Upload(UIElement):
         elif action == "remove":
             key = data.get("key", "")
             self._files.pop(key, None)
+            self._remove_from_workspace(key)
             self.send_update(upload_status={key: "removed"})
             super().handle_interaction(data)
 
@@ -1502,6 +1890,7 @@ class Upload(UIElement):
                             status[key] = f"error:File exceeds max size ({max_size} bytes)"
                         else:
                             self._files[key] = raw
+                            self._persist_to_workspace(key, raw)
                             status[key] = "success"
                     except Exception as e:
                         status[key] = f"error:{e}"
@@ -2266,6 +2655,7 @@ class Chart(UIElement):
 `);
 
         await pyodide.runPythonAsync(INIT_CODE);
+        await setupWorkspaceFs();
 
         // Register stream callback
         const register_cb = pyodide.globals.get("register_stream_callback");
@@ -2384,6 +2774,22 @@ self.onmessage = async (e) => {
             } catch (err) {
                 console.error("Clear cell context error", err);
             }
+        }
+    } else if (type === "filesystem") {
+        if (!pyodide) {
+            postMessage({ type: "filesystem_result", id, ok: false, error: "Kernel not ready" });
+            return;
+        }
+        try {
+            const result = await handleFilesystemRequest(e.data.request);
+            postMessage({ type: "filesystem_result", id, ok: true, result });
+        } catch (err) {
+            postMessage({
+                type: "filesystem_result",
+                id,
+                ok: false,
+                error: err instanceof Error ? err.message : String(err),
+            });
         }
     } else if (type === "analyze_cell") {
         // Reactive execution mode: analyze cell dependencies using Python AST

--- a/src/lib/testids.ts
+++ b/src/lib/testids.ts
@@ -16,6 +16,13 @@ export const TESTID = {
   addMarkdownCell: "add-markdown-cell",
   cell: "cell",
   cellOutput: "cell-output",
+  filesPanelRoot: "files-panel-root",
+  filesPanelRow: "files-panel-row",
+  filesPanelBreadcrumb: "files-panel-breadcrumb",
+  filesPanelError: "files-panel-error",
+  filesDialog: "files-panel-dialog",
+  filesSidePanel: "files-panel-side",
+  uploadComponent: "upload-component",
 } as const;
 
 export type TestId = (typeof TESTID)[keyof typeof TESTID];

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -533,6 +533,15 @@ export const saveThemeAppWide = () => {
     // Update preloader colors immediately
     localStorage.setItem("theme_bg", theme.colors.background);
     localStorage.setItem("theme_text", theme.colors.secondary);
+
+    const root = document.documentElement;
+    const body = document.body;
+    root.style.setProperty("--background", theme.colors.background);
+    root.style.setProperty("--secondary", theme.colors.secondary);
+    root.style.backgroundColor = theme.colors.background;
+    body.style.backgroundColor = theme.colors.background;
+    const metaTheme = document.getElementById("meta-theme-color");
+    if (metaTheme) metaTheme.setAttribute("content", theme.colors.background);
   } catch (e) {
     console.warn("Failed to save theme:", e);
   }
@@ -565,6 +574,7 @@ export const parseUiBorder = (value: string, fallbackColor: string, fallbackWidt
 export const initTheme = () => {
   createEffect(() => {
     const root = document.documentElement;
+    const body = document.body;
     root.style.setProperty("--font-mono", theme.font);
     root.style.setProperty("--font-weight-base", theme.fontWeight || "normal");
 
@@ -579,6 +589,8 @@ export const initTheme = () => {
     root.style.setProperty("--error", theme.colors.error);
     root.style.setProperty("--warning", theme.colors.warning);
     root.style.setProperty("--info", theme.colors.info);
+    root.style.backgroundColor = theme.colors.background;
+    body.style.backgroundColor = theme.colors.background;
 
     // DaisyUI variables (not using @theme inline, set directly)
     root.style.setProperty("--color-base-100", theme.colors.background);


### PR DESCRIPTION
Adds a full internal filesystem management layer within the notebook runtime and adds a file explorer panel and dialog to the app UI.

## What’s in here

- Worker-backed filesystem operations for upload, create folder, rename, move, copy, delete, and download
- New Files and Data panel implementation with list mode and tree mode
- Folder expand/collapse behavior in tree mode (including selected-folder controls)
- Drag and drop improvements with immediate UI updates after file/folder operations
- Shared view-mode ownership between side panel and dialog panel so state stays in sync
- Mode persistence for list/tree preference
- Upload integration updates and panel wiring in Notebook
- Test IDs/selectors updates for stability
- New end-to-end coverage for Files and Data workflows
- Architecture docs for Files and Data panel internals

## Why this change

- Filesystem features were growing, but the old flow was becoming hard to reason about
- Panel behavior needed to be consistent across responsive layouts
- We needed a stronger internal foundation before adding more file features

## Result

- Internal filesystem management is now a first-class system, not just UI patch/hack
- Files and Data behavior is more predictable, more complete, and easier to extend