### PR TITLE
Runtime Google Fonts loading + letter spacing, execution count toggle, and file save fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <!-- Critical for preventing white flash on new tabs -->
     <meta name="theme-color" id="meta-theme-color" content="#1e1e2e" />
+    <!-- Speeds up runtime loading of theme fonts that aren't bundled -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <title>PyNote</title>
     <script>
       (function() {

--- a/scripts/tmp-font-timing.mjs
+++ b/scripts/tmp-font-timing.mjs
@@ -1,0 +1,88 @@
+import { chromium } from "playwright";
+
+const URL = "http://127.0.0.1:5199/";
+const browser = await chromium.launch();
+const context = await browser.newContext();
+
+await context.addInitScript(() => {
+  window.__firstRenderMs = null;
+  const poll = () => {
+    const root = document.getElementById("root");
+    if (root && root.firstChild) {
+      window.__firstRenderMs = performance.now();
+      return;
+    }
+    requestAnimationFrame(poll);
+  };
+  requestAnimationFrame(poll);
+});
+
+const page = await context.newPage();
+const requests = [];
+page.on("request", (req) => {
+  const u = req.url();
+  if (u.includes("fonts.googleapis.com") || u.includes("fonts.gstatic.com")) {
+    requests.push(u.slice(0, 90));
+  }
+});
+
+const measure = async (label) => {
+  requests.length = 0;
+  await page.goto(URL, { waitUntil: "load" });
+  await page.waitForSelector("#root > *", { timeout: 20000 });
+  const ms = await page.evaluate(() => window.__firstRenderMs);
+  console.log(`${label}: firstRender=${ms?.toFixed(0)}ms, fontRequests=${requests.length}`);
+  for (const r of requests) console.log(`   ${r}`);
+};
+
+// establish origin
+await page.goto(URL, { waitUntil: "domcontentloaded" });
+
+// A: bundled font theme (no Google fonts involved)
+await page.evaluate(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("pynote-theme", JSON.stringify({ font: '"JetBrains Mono Variable", monospace' }));
+});
+await measure("A bundled font, refresh");
+await measure("A bundled font, refresh 2");
+
+// B: Google font theme, cold
+await page.evaluate(() => {
+  localStorage.setItem("pynote-theme", JSON.stringify({ font: '"Fira Code", monospace' }));
+  sessionStorage.clear();
+});
+await measure("B google font, first load");
+
+// C: Google font theme, warm (sessionStorage CSS + HTTP cache)
+await measure("C google font, refresh");
+await measure("C google font, refresh 2");
+
+// D: existing session whose theme has a Google font, but nothing cached
+// (fresh tab). Must NOT block render; font swaps in when ready.
+await page.evaluate(() => {
+  const id = "timing-test-session";
+  localStorage.setItem(
+    "pynote-session-" + id,
+    JSON.stringify({ cells: [{ id: "c1", type: "markdown", content: "# hi" }], filename: "t.ipynb", theme: { font: '"Fira Code", monospace' } })
+  );
+  sessionStorage.clear();
+});
+const dUrl = URL + "?session=timing-test-session";
+requests.length = 0;
+await page.goto(dUrl, { waitUntil: "load" });
+await page.waitForSelector("#root > *", { timeout: 20000 });
+const dMs = await page.evaluate(() => window.__firstRenderMs);
+console.log(`D existing session, uncached google font: firstRender=${dMs?.toFixed(0)}ms, fontRequests=${requests.length}`);
+
+// E: refresh of the same session, font CSS now session-cached by D's
+// background load. This is the everyday refresh case.
+for (const n of [1, 2]) {
+  requests.length = 0;
+  await page.goto(dUrl, { waitUntil: "load" });
+  await page.waitForSelector("#root > *", { timeout: 20000 });
+  const eMs = await page.evaluate(() => window.__firstRenderMs);
+  console.log(`E existing session, cached google font, refresh ${n}: firstRender=${eMs?.toFixed(0)}ms, fontRequests=${requests.length}`);
+}
+
+await browser.close();

--- a/scripts/tmp-font-timing.mjs
+++ b/scripts/tmp-font-timing.mjs
@@ -31,7 +31,11 @@ const measure = async (label) => {
   await page.goto(URL, { waitUntil: "load" });
   await page.waitForSelector("#root > *", { timeout: 20000 });
   const ms = await page.evaluate(() => window.__firstRenderMs);
+  const marks = await page.evaluate(() =>
+    performance.getEntriesByType("mark").map((m) => `${m.name}@${m.startTime.toFixed(0)}`).join(" ")
+  );
   console.log(`${label}: firstRender=${ms?.toFixed(0)}ms, fontRequests=${requests.length}`);
+  console.log(`   marks: ${marks}`);
   for (const r of requests) console.log(`   ${r}`);
 };
 
@@ -58,31 +62,12 @@ await measure("B google font, first load");
 await measure("C google font, refresh");
 await measure("C google font, refresh 2");
 
-// D: existing session whose theme has a Google font, but nothing cached
-// (fresh tab). Must NOT block render; font swaps in when ready.
+// A again at the end: if this is now slow too, the C slowdown is an order
+// artifact of the harness, not the font path.
 await page.evaluate(() => {
-  const id = "timing-test-session";
-  localStorage.setItem(
-    "pynote-session-" + id,
-    JSON.stringify({ cells: [{ id: "c1", type: "markdown", content: "# hi" }], filename: "t.ipynb", theme: { font: '"Fira Code", monospace' } })
-  );
-  sessionStorage.clear();
+  localStorage.setItem("pynote-theme", JSON.stringify({ font: '"JetBrains Mono Variable", monospace' }));
 });
-const dUrl = URL + "?session=timing-test-session";
-requests.length = 0;
-await page.goto(dUrl, { waitUntil: "load" });
-await page.waitForSelector("#root > *", { timeout: 20000 });
-const dMs = await page.evaluate(() => window.__firstRenderMs);
-console.log(`D existing session, uncached google font: firstRender=${dMs?.toFixed(0)}ms, fontRequests=${requests.length}`);
-
-// E: refresh of the same session, font CSS now session-cached by D's
-// background load. This is the everyday refresh case.
-for (const n of [1, 2]) {
-  requests.length = 0;
-  await page.goto(dUrl, { waitUntil: "load" });
-  await page.waitForSelector("#root > *", { timeout: 20000 });
-  const eMs = await page.evaluate(() => window.__firstRenderMs);
-  console.log(`E existing session, cached google font, refresh ${n}: firstRender=${eMs?.toFixed(0)}ms, fontRequests=${requests.length}`);
-}
+await measure("A2 bundled font, at end");
+await measure("A2 bundled font, at end 2");
 
 await browser.close();

--- a/scripts/tmp-verify-exec-count-scope.mjs
+++ b/scripts/tmp-verify-exec-count-scope.mjs
@@ -1,0 +1,27 @@
+import { chromium } from "playwright";
+
+const URL = "http://127.0.0.1:5199/";
+const browser = await chromium.launch();
+const page = await (await browser.newContext()).newPage();
+
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector(".cm-editor", { timeout: 15000 });
+
+// Select the code cell so the dialog opens in cell scope.
+await page.locator(".cm-editor").first().click();
+await page.keyboard.press("Escape"); // stay selected, exit edit mode
+await page.keyboard.press("Alt+v");
+await page.waitForSelector("text=Code Cell Visibility");
+
+const inCellScope = await page.locator("text=Execution Count").count();
+
+// Switch scope to Notebook via the Cell/Notebook slider.
+await page.locator('div.fixed:has-text("Code Cell Visibility")').locator("text=Notebook").last().click();
+await page.waitForTimeout(200);
+const inNotebookScope = await page.locator("text=Execution Count").count();
+
+console.log(JSON.stringify({ inCellScope, inNotebookScope }));
+const pass = inCellScope === 0 && inNotebookScope === 1;
+console.log(pass ? "PASS" : "FAIL");
+await browser.close();
+process.exit(pass ? 0 : 1);

--- a/scripts/tmp-verify-exec-count.mjs
+++ b/scripts/tmp-verify-exec-count.mjs
@@ -1,0 +1,46 @@
+import { chromium } from "playwright";
+
+const URL = "http://127.0.0.1:5199/";
+const browser = await chromium.launch();
+const page = await (await browser.newContext()).newPage();
+
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector(".cm-editor", { timeout: 15000 });
+
+const gutterCount = () => page.evaluate(() =>
+  [...document.querySelectorAll("div")].filter((d) => /^\[\d+\]:$/.test(d.textContent?.trim() ?? "") && d.childElementCount === 0).length
+);
+const editorWidth = () => page.evaluate(() => document.querySelector(".cm-editor").getBoundingClientRect().width);
+
+const before = { gutters: await gutterCount(), width: await editorWidth() };
+console.log("before:", JSON.stringify(before));
+
+// Open the visibility dialog, uncheck Execution Count, save.
+await page.keyboard.press("Alt+v");
+await page.waitForSelector("text=Code Cell Visibility");
+await page.locator("text=Execution Count").click();
+await page.locator('div.fixed:has-text("Code Cell Visibility") button:has-text("Save")').click();
+await page.waitForSelector("text=Code Cell Visibility", { state: "detached" });
+await page.waitForTimeout(300);
+
+const after = { gutters: await gutterCount(), width: await editorWidth() };
+console.log("after:", JSON.stringify(after));
+
+// Toggle back on to confirm it round-trips.
+await page.keyboard.press("Alt+v");
+await page.waitForSelector("text=Code Cell Visibility");
+await page.locator("text=Execution Count").click();
+await page.locator('div.fixed:has-text("Code Cell Visibility") button:has-text("Save")').click();
+await page.waitForSelector("text=Code Cell Visibility", { state: "detached" });
+await page.waitForTimeout(300);
+const restored = { gutters: await gutterCount(), width: await editorWidth() };
+console.log("restored:", JSON.stringify(restored));
+
+const pass =
+  before.gutters > 0 &&
+  after.gutters === 0 &&
+  after.width > before.width + 30 &&
+  restored.gutters === before.gutters;
+console.log(pass ? "PASS" : "FAIL");
+await browser.close();
+process.exit(pass ? 0 : 1);

--- a/scripts/tmp-verify-google-font.mjs
+++ b/scripts/tmp-verify-google-font.mjs
@@ -1,0 +1,75 @@
+import { chromium } from "playwright";
+
+const URL = "http://127.0.0.1:5199/";
+const browser = await chromium.launch();
+const context = await browser.newContext();
+
+// Record whether the Google font was already usable at the moment the app
+// first rendered anything into #root (i.e. font landed with the theme).
+await context.addInitScript(() => {
+  window.__fontReadyAtFirstRender = "no-render";
+  const poll = () => {
+    const root = document.getElementById("root");
+    if (root && root.firstChild) {
+      window.__fontReadyAtFirstRender = document.fonts.check('16px "Fira Code"');
+      return;
+    }
+    requestAnimationFrame(poll);
+  };
+  requestAnimationFrame(poll);
+});
+
+const page = await context.newPage();
+
+// Visit once to establish the origin, then set an app theme that references
+// a Google font that is not bundled with the app.
+await page.goto(URL, { waitUntil: "domcontentloaded" });
+await page.evaluate(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    "pynote-theme",
+    JSON.stringify({ font: '"Fira Code", monospace' })
+  );
+});
+
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector("#root > *", { timeout: 15000 });
+
+const result = await page.evaluate(() => ({
+  fontReadyAtFirstRender: window.__fontReadyAtFirstRender,
+  fontLoadedNow: document.fonts.check('16px "Fira Code"'),
+  styleTagInjected: !!document.querySelector('style[data-google-font="Fira Code"]'),
+  fontMonoVar: getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim(),
+}));
+
+console.log(JSON.stringify(result, null, 2));
+
+// Reload: same session cache (sessionStorage CSS) should serve the font with
+// zero requests to the Google Fonts CSS endpoint.
+let cssRequests = 0;
+page.on("request", (req) => {
+  if (req.url().startsWith("https://fonts.googleapis.com/")) cssRequests++;
+});
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector("#root > *", { timeout: 15000 });
+const reload = await page.evaluate(() => ({
+  fontReadyAtFirstRender: window.__fontReadyAtFirstRender,
+  cssCached: !!sessionStorage.getItem("pynote-gfont-Fira Code"),
+}));
+console.log(JSON.stringify({ ...reload, cssRequests }, null, 2));
+
+// Second scenario: bundled font stays untouched (no Google fetch).
+await page.evaluate(() => {
+  localStorage.setItem(
+    "pynote-theme",
+    JSON.stringify({ font: '"JetBrains Mono Variable", monospace' })
+  );
+});
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector("#root > *", { timeout: 15000 });
+const bundled = await page.evaluate(() => ({
+  googleStyleTags: document.querySelectorAll("style[data-google-font]").length,
+}));
+console.log(JSON.stringify(bundled, null, 2));
+
+await browser.close();

--- a/scripts/tmp-verify-handle-persistence.mjs
+++ b/scripts/tmp-verify-handle-persistence.mjs
@@ -1,0 +1,79 @@
+import { chromium } from "playwright";
+
+const URL = "http://127.0.0.1:5199/";
+const browser = await chromium.launch();
+const context = await browser.newContext();
+
+// Route the open picker to a real OPFS-backed FileSystemFileHandle (cloneable,
+// writable without prompts, so the genuine IndexedDB persistence is exercised).
+// Also flag if the save picker or a download ever gets used.
+await context.addInitScript(() => {
+  window.__savePickerUsed = false;
+  window.__openPickerUsed = false;
+  window.showOpenFilePicker = async () => {
+    window.__openPickerUsed = true;
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle("roundtrip.ipynb", { create: false });
+    return [handle];
+  };
+  window.showSaveFilePicker = async () => {
+    window.__savePickerUsed = true;
+    throw new DOMException("nope", "AbortError");
+  };
+});
+
+const page = await context.newPage();
+let downloads = 0;
+page.on("download", () => downloads++);
+page.on("console", (m) => { if (m.type() === "error" || m.type() === "warning") console.log("[page]", m.text().slice(0, 200)); });
+page.on("dialog", (d) => { console.log("[dialog]", d.message()); d.dismiss().catch(() => {}); });
+
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector("#root > *");
+
+// Seed the OPFS file with a minimal valid notebook.
+await page.evaluate(async () => {
+  const nb = {
+    cells: [{ cell_type: "markdown", source: ["# handle test"], metadata: {}, outputs: [] }],
+    metadata: {}, nbformat: 4, nbformat_minor: 5,
+  };
+  const root = await navigator.storage.getDirectory();
+  const handle = await root.getFileHandle("roundtrip.ipynb", { create: true });
+  const w = await handle.createWritable();
+  await w.write(JSON.stringify(nb));
+  await w.close();
+});
+
+// Open it (Cmd+O goes through the mocked picker; handle path, no reload).
+await page.keyboard.press("ControlOrMeta+o");
+await page.waitForFunction(() => document.body.innerText.includes("handle test"), null, { timeout: 8000 });
+console.log("file opened, handle path");
+
+// Refresh. The localStorage session restores; the handle must come from IndexedDB.
+await page.reload({ waitUntil: "load" });
+await page.waitForSelector("#root > *");
+await page.waitForTimeout(600); // allow async handle restore
+console.log("reloaded, session restored:", await page.evaluate(() => document.body.innerText.includes("handle test")));
+
+// Save. Should write to the original file, not picker/download.
+await page.keyboard.press("ControlOrMeta+s");
+await page.waitForTimeout(800);
+
+const result = await page.evaluate(async () => {
+  const root = await navigator.storage.getDirectory();
+  const handle = await root.getFileHandle("roundtrip.ipynb");
+  const text = await (await handle.getFile()).text();
+  let parsed = null;
+  try { parsed = JSON.parse(text); } catch {}
+  return {
+    savedByApp: !!parsed?.metadata?.PyNote,
+    cellsPreserved: parsed?.cells?.[0]?.source?.join("").includes("# handle test"),
+    savePickerUsed: window.__savePickerUsed,
+  };
+});
+console.log(JSON.stringify({ ...result, downloads }, null, 2));
+
+const pass = result.savedByApp && result.cellsPreserved && !result.savePickerUsed && downloads === 0;
+console.log(pass ? "PASS" : "FAIL");
+await browser.close();
+process.exit(pass ? 0 : 1);

--- a/scripts/tmp-verify-outputlayout.mjs
+++ b/scripts/tmp-verify-outputlayout.mjs
@@ -1,0 +1,77 @@
+import { chromium } from "playwright";
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs";
+import os from "os";
+
+const URL = "http://127.0.0.1:5199/";
+const repo = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const themedNb = path.join(repo, "themed-notebooks/magic_dark_theme_notebook.ipynb");
+
+const browser = await chromium.launch();
+const context = await browser.newContext();
+
+// Capture what the app writes through the save picker.
+await context.addInitScript(() => {
+  window.__savedContent = null;
+  window.showSaveFilePicker = async () => ({
+    createWritable: async () => ({
+      write: async (c) => { window.__savedContent = c; },
+      close: async () => {},
+    }),
+  });
+});
+
+const page = await context.newPage();
+
+const openVisibilityDialogAndAssert = async (expected) => {
+  await page.keyboard.press("Alt+v");
+  await page.waitForSelector("text=Code Cell Visibility", { timeout: 5000 });
+  const btn = page.locator('button[title^="Output position:"]');
+  await btn.waitFor({ timeout: 5000 });
+  const text = (await btn.innerText()).trim();
+  console.log(`dialog toggle shows: "${text}" (expected ${expected})`);
+  return { btn, text };
+};
+
+// 1. Load the themed notebook (embedded theme has outputLayout "above") via
+//    the fallback input, which reloads into a new session.
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForSelector("#root > *");
+const input = page.locator('input[accept=".ipynb"]');
+await Promise.all([
+  page.waitForNavigation({ timeout: 15000 }),
+  input.setInputFiles(themedNb),
+]);
+await page.waitForSelector("#root > *");
+
+// 2. Open the visibility dialog, confirm it starts at "above" (the preset
+//    value), toggle to "below", check "Save settings to .ipynb", save.
+const { btn, text } = await openVisibilityDialogAndAssert("above");
+if (text.includes("above")) await btn.click();
+console.log("after click:", (await btn.innerText()).trim());
+await page.locator("text=Save settings to .ipynb").click();
+await page.locator('button:has-text("Save")').last().click();
+
+// 3. Save the notebook (Cmd/Ctrl+S goes through the mocked picker).
+await page.keyboard.press("ControlOrMeta+s");
+await page.waitForFunction(() => window.__savedContent !== null, { timeout: 5000 });
+const saved = JSON.parse(await page.evaluate(() => window.__savedContent));
+const savedTheme = saved.metadata?.PyNote?.theme;
+console.log("saved theme.outputLayout:", savedTheme?.outputLayout);
+console.log("saved codeview present:", !!saved.metadata?.PyNote?.codeview);
+
+// 4. Round trip: load the just-saved file back and confirm the dialog shows "below".
+const tmp = path.join(os.tmpdir(), "outputlayout-roundtrip.ipynb");
+fs.writeFileSync(tmp, JSON.stringify(saved));
+await Promise.all([
+  page.waitForNavigation({ timeout: 15000 }),
+  page.locator('input[accept=".ipynb"]').setInputFiles(tmp),
+]);
+await page.waitForSelector("#root > *");
+const reopened = await openVisibilityDialogAndAssert("below");
+
+const pass = savedTheme?.outputLayout === "below" && reopened.text.includes("below");
+console.log(pass ? "PASS" : "FAIL");
+await browser.close();
+process.exit(pass ? 0 : 1);

--- a/src/__tests__/unit/theme-vars.test.ts
+++ b/src/__tests__/unit/theme-vars.test.ts
@@ -183,6 +183,28 @@ describe("syntax, radii, spacing and typography inputs", () => {
     await tick();
     expect(cssVar("--font-mono")).toBe('"Test Mono", monospace');
   });
+
+  test("letter spacing maps to base, code and ui variables", async () => {
+    updateTheme({
+      typography: { letterSpacing: "0.05em" },
+      codeTypography: { letterSpacing: "0.1em" },
+      uiTypography: { letterSpacing: "0.02em" },
+    });
+    await tick();
+    expect(cssVar("--letter-spacing-base")).toBe("0.05em");
+    expect(cssVar("--code-letter-spacing")).toBe("0.1em");
+    expect(cssVar("--ui-letter-spacing")).toBe("0.02em");
+
+    updateTheme({
+      typography: { letterSpacing: "" },
+      codeTypography: { letterSpacing: "" },
+      uiTypography: { letterSpacing: "" },
+    });
+    await tick();
+    expect(cssVar("--letter-spacing-base")).toBe("normal");
+    expect(cssVar("--code-letter-spacing")).toBe("normal");
+    expect(cssVar("--ui-letter-spacing")).toBe("var(--letter-spacing-base)");
+  });
 });
 
 describe("layout inputs", () => {

--- a/src/components/CodeCell.tsx
+++ b/src/components/CodeCell.tsx
@@ -37,7 +37,8 @@ const CodeCell: Component<CodeCellProps> = (props) => {
   const cellHasHiddenElements = () => {
     const v = visibility();
     return !v.showCode || !v.showStdout || !v.showStderr ||
-           !v.showResult || !v.showError || !v.showStatusDot;
+           !v.showResult || !v.showError || !v.showStatusDot ||
+           !v.showExecutionCount;
   };
 
   // Check if cell has any actual output content (regardless of visibility settings)
@@ -154,21 +155,23 @@ const CodeCell: Component<CodeCellProps> = (props) => {
             ...(currentTheme.codeBlock.outerPadding ? { padding: currentTheme.codeBlock.outerPadding } : {}),
           }}
         >
-           {/* Line numbers gutter could go here */}
-           <div
-             class={clsx(
-               "w-10 bg-background flex flex-col items-center pt-5.5 pr-1.5 text-xs select-none font-mono shrink-0",
-               currentTheme.codeBlock.gutterBorderRightOn && !currentTheme.codeBlock.gutterBorderRight && "border-r ui-border-color",
-               props.cell.outputs?.executionKernelId === kernel.id ? "text-secondary/50 font-bold" : "text-foreground"
-             )}
-             style={{
-               ...(currentTheme.codeBlock.gutterBorderRightOn && currentTheme.codeBlock.gutterBorderRight ? { "border-right": currentTheme.codeBlock.gutterBorderRight } : {}),
-               ...(currentTheme.codeBlock.gutterRadius ? { "border-radius": currentTheme.codeBlock.gutterRadius } : {}),
-               ...(currentTheme.codeBlock.gutterBackground ? { background: currentTheme.codeBlock.gutterBackground } : {}),
-             }}
-           >
-              [{props.index + 1}]:
-           </div>
+           {/* Execution count gutter. When hidden, the editor (flex-1) takes the full width */}
+           <Show when={visibility().showExecutionCount}>
+             <div
+               class={clsx(
+                 "w-10 bg-background flex flex-col items-center pt-5.5 pr-1.5 text-xs select-none font-mono shrink-0",
+                 currentTheme.codeBlock.gutterBorderRightOn && !currentTheme.codeBlock.gutterBorderRight && "border-r ui-border-color",
+                 props.cell.outputs?.executionKernelId === kernel.id ? "text-secondary/50 font-bold" : "text-foreground"
+               )}
+               style={{
+                 ...(currentTheme.codeBlock.gutterBorderRightOn && currentTheme.codeBlock.gutterBorderRight ? { "border-right": currentTheme.codeBlock.gutterBorderRight } : {}),
+                 ...(currentTheme.codeBlock.gutterRadius ? { "border-radius": currentTheme.codeBlock.gutterRadius } : {}),
+                 ...(currentTheme.codeBlock.gutterBackground ? { background: currentTheme.codeBlock.gutterBackground } : {}),
+               }}
+             >
+                [{props.index + 1}]:
+             </div>
+           </Show>
            <div
              class="flex-1 min-w-0 bg-accent/2 relative"
              style={{

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -528,6 +528,7 @@ const CodeEditor: Component<EditorProps> = (props) => {
       fontSize: "var(--code-editor-font-size)",
       fontFamily: "var(--code-font-family)",
       fontWeight: "var(--code-font-weight)",
+      letterSpacing: "var(--code-letter-spacing, normal)",
     },
     ".cm-content": {
       caretColor: "var(--accent) !important",

--- a/src/components/CodeVisibilityDialog.tsx
+++ b/src/components/CodeVisibilityDialog.tsx
@@ -119,6 +119,10 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       props.onClose();
     } else {
       // Notebook-scoped save (existing behavior)
+      // Capture the layout selection first: the updateVisibility writes below
+      // re-run the dialog's sync effect, which resets localOutputLayout from
+      // the (not yet updated) theme and would clobber the user's choice.
+      const outputLayout = localOutputLayout();
       updateVisibility("showCode", settings.showCode);
       updateVisibility("showStdout", settings.showStdout);
       updateVisibility("showStderr", settings.showStderr);
@@ -131,7 +135,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       // Persist visibility to localStorage
       saveVisibilitySettings();
       // Update theme output layout
-      updateTheme({ outputLayout: localOutputLayout() });
+      updateTheme({ outputLayout });
       // Notify parent to trigger session autosave
       props.onSave?.();
       props.onClose();

--- a/src/components/CodeVisibilityDialog.tsx
+++ b/src/components/CodeVisibilityDialog.tsx
@@ -1,5 +1,5 @@
 import { type Component, createSignal, createEffect, Show } from "solid-js";
-import { X, Code, EyeOff, TriangleAlert, Terminal, FileOutput, AlertCircle, CircleDot, ArrowUp, ArrowDown, Hash, WrapText, RotateCcw } from "lucide-solid";
+import { X, Code, EyeOff, TriangleAlert, Terminal, FileOutput, AlertCircle, CircleDot, ArrowUp, ArrowDown, Hash, WrapText, RotateCcw, Brackets } from "lucide-solid";
 import clsx from "clsx";
 import { 
   codeVisibility, 
@@ -36,6 +36,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
     showResult: codeVisibility.showResult,
     showError: codeVisibility.showError,
     showStatusDot: codeVisibility.showStatusDot,
+    showExecutionCount: codeVisibility.showExecutionCount,
     saveToExport: codeVisibility.saveToExport,
     showLineNumbers: codeVisibility.showLineNumbers,
     lineWrap: codeVisibility.lineWrap,
@@ -57,6 +58,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       showResult: cellCv?.showResult ?? codeVisibility.showResult,
       showError: cellCv?.showError ?? codeVisibility.showError,
       showStatusDot: cellCv?.showStatusDot ?? codeVisibility.showStatusDot,
+      showExecutionCount: codeVisibility.showExecutionCount, // notebook-level only
       saveToExport: codeVisibility.saveToExport, // saveToExport applies at both levels
       showLineNumbers: codeVisibility.showLineNumbers,
       lineWrap: codeVisibility.lineWrap,
@@ -72,6 +74,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       showResult: codeVisibility.showResult,
       showError: codeVisibility.showError,
       showStatusDot: codeVisibility.showStatusDot,
+      showExecutionCount: codeVisibility.showExecutionCount,
       saveToExport: codeVisibility.saveToExport,
       showLineNumbers: codeVisibility.showLineNumbers,
       lineWrap: codeVisibility.lineWrap,
@@ -129,6 +132,7 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
       updateVisibility("showResult", settings.showResult);
       updateVisibility("showError", settings.showError);
       updateVisibility("showStatusDot", settings.showStatusDot);
+      updateVisibility("showExecutionCount", settings.showExecutionCount);
       updateVisibility("saveToExport", settings.saveToExport);
       updateVisibility("showLineNumbers", settings.showLineNumbers);
       updateVisibility("lineWrap", settings.lineWrap);
@@ -294,6 +298,10 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
             </div>
             <div class="space-y-0.5">
               <CheckboxRow itemKey="showCode" label="Code Editor" icon={Code} iconColor="text-accent" hasEditorToggles={true} />
+              {/* Notebook-level only: hidden in cell scope */}
+              <Show when={applyScope() === "notebook"}>
+                <CheckboxRow itemKey="showExecutionCount" label="Execution Count" icon={Brackets} iconColor="text-secondary/70" />
+              </Show>
               <CheckboxRow itemKey="showStatusDot" label="Status Indicator" icon={CircleDot} iconColor="text-success" />
               <CheckboxRow itemKey="showStdout" label="Standard Output" icon={Terminal} iconColor="text-secondary" hasPositionToggle={true} />
               <CheckboxRow itemKey="showResult" label="Return Value" icon={FileOutput} iconColor="text-secondary/70" />
@@ -329,7 +337,9 @@ const CodeVisibilityDialog: Component<CodeVisibilityDialogProps> = (props) => {
                 !localSettings().showCode && "hidden"
               )}>
                 <div class="flex gap-2">
-                  <span class="text-secondary/50 select-none">[1]:</span>
+                  <Show when={localSettings().showExecutionCount}>
+                    <span class="text-secondary/50 select-none">[1]:</span>
+                  </Show>
                   <div class="flex gap-2 flex-1">
                     <Show when={localSettings().showLineNumbers}>
                       <div class="text-secondary/30 select-none text-right" style="min-width: 1.5em;">

--- a/src/components/Notebook.tsx
+++ b/src/components/Notebook.tsx
@@ -15,6 +15,7 @@ import { sessionManager } from "../lib/session";
 import { codeVisibility, setVisibilitySettings, resetUserOverride, getSessionState, restoreSessionState, setOnCellOverrideChange, applyDocumentSettings, shouldLoadMetadataSettings, shouldAutoRun, shouldAutoRunOnRefresh, type CodeVisibilitySettings } from "../lib/codeVisibility";
 import { currentTheme, updateTheme, saveThemeAppWide, loadAppTheme, defaultTheme } from "../lib/theme";
 import { loadThemeFonts } from "../lib/font-loader";
+import { saveFileHandle, loadFileHandle } from "../lib/file-handles";
 import { TESTID } from "../lib/testids";
 import FileWorkspacePanel from "./FileWorkspacePanel";
 import SideShortcuts from "./notebook/SideShortcuts";
@@ -700,6 +701,13 @@ const Notebook: Component = () => {
         } else {
           setSessionHasTheme(false);
         }
+
+        // Restore the opened file's handle (persisted in IndexedDB; survives
+        // reloads unlike the localStorage session). Save re-requests write
+        // permission if the browser dropped it.
+        loadFileHandle(sessionId).then((h) => {
+          if (h && !fileHandle) fileHandle = h;
+        });
         
         // Restore code visibility state if session has it
         if (data.codeVisibility) {
@@ -1018,7 +1026,16 @@ const Notebook: Component = () => {
               return pruneEmptyThemeOverrides(themeToExport, defaultTheme);
             })()
           } : loadedDocumentTheme ? {
-            theme: loadedDocumentTheme
+            // Write back the original document theme, but the above/below
+            // output toggle lives in the code visibility dialog and is stored
+            // on the theme, so when that dialog's save-to-export is on the
+            // current toggle state must win over the stale written-back value.
+            theme: codeVisibility.saveToExport
+              ? { ...loadedDocumentTheme, outputLayout: currentTheme.outputLayout }
+              : loadedDocumentTheme
+          } : codeVisibility.saveToExport ? {
+            // No theme in the document: persist just the output toggle.
+            theme: { outputLayout: currentTheme.outputLayout }
           } : {})
         }
       },
@@ -1054,8 +1071,10 @@ const Notebook: Component = () => {
       await writable.write(content);
       await writable.close();
       
-      // Update fileHandle for future saves
+      // Update fileHandle for future saves (and future reloads)
       fileHandle = handle;
+      const sid = sessionManager.getSessionIdFromUrl();
+      if (sid) void saveFileHandle(sid, handle);
       
       return true;
     } catch (err: any) {
@@ -1073,6 +1092,14 @@ const Notebook: Component = () => {
     // If we have a file handle from opening a file, save directly to it
     if (fileHandle) {
       try {
+        // A handle restored after a reload may have lost write permission;
+        // re-request it here (Save is a user gesture, so prompting is allowed).
+        const h = fileHandle as any;
+        if (h.queryPermission && (await h.queryPermission({ mode: "readwrite" })) !== "granted") {
+          if ((await h.requestPermission?.({ mode: "readwrite" })) !== "granted") {
+            throw new Error("write permission not granted");
+          }
+        }
         const writable = await fileHandle.createWritable();
         await writable.write(content);
         await writable.close();
@@ -1248,6 +1275,9 @@ const Notebook: Component = () => {
           url.searchParams.set("session", newSessionId);
           url.searchParams.delete("open");
           window.history.replaceState({}, "", url.toString());
+          
+          // Persist the handle so saves keep targeting this file after reloads
+          void saveFileHandle(newSessionId, handle);
           
           // Trigger autosave to persist the new session
           autosaveNotebookImmediate();

--- a/src/components/Notebook.tsx
+++ b/src/components/Notebook.tsx
@@ -14,6 +14,7 @@ import Dropdown, { DropdownItem, DropdownDivider } from "./ui/Dropdown";
 import { sessionManager } from "../lib/session";
 import { codeVisibility, setVisibilitySettings, resetUserOverride, getSessionState, restoreSessionState, setOnCellOverrideChange, applyDocumentSettings, shouldLoadMetadataSettings, shouldAutoRun, shouldAutoRunOnRefresh, type CodeVisibilitySettings } from "../lib/codeVisibility";
 import { currentTheme, updateTheme, saveThemeAppWide, loadAppTheme, defaultTheme } from "../lib/theme";
+import { loadThemeFonts } from "../lib/font-loader";
 import { TESTID } from "../lib/testids";
 import FileWorkspacePanel from "./FileWorkspacePanel";
 import SideShortcuts from "./notebook/SideShortcuts";
@@ -1109,7 +1110,7 @@ const Notebook: Component = () => {
   };
 
   // Process loaded notebook content (shared between file input and File System Access API)
-  const processLoadedNotebook = (content: string, filename: string, handle: FileSystemFileHandle | null) => {
+  const processLoadedNotebook = async (content: string, filename: string, handle: FileSystemFileHandle | null) => {
     try {
       const nb = JSON.parse(content);
       if (nb.cells && Array.isArray(nb.cells)) {
@@ -1205,16 +1206,22 @@ const Notebook: Component = () => {
           ? nb.metadata.PyNote.codeHiddenPlaceholder
           : undefined;
         
-        // Store the file handle for later saving (only if opened via File System Access API)
-        fileHandle = handle;
-        
         // If we have a file handle, load directly without page reload to preserve it
         if (handle) {
-          // Apply theme if document has one
+          // Apply theme if document has one. Give any Google fonts the theme
+          // references a short head start (bounded, so opening a file never
+          // hangs on the network) so the font usually arrives in the same
+          // paint as the rest of the theme. Past the cap it swaps in when
+          // ready instead.
           if (themeData) {
+            await loadThemeFonts(themeData, 250);
             updateTheme(themeData);
             setSessionHasTheme(true);
           }
+          
+          // Store the file handle for later saving. Assigned only now, after
+          // the font wait, so saves during the wait still target the old file.
+          fileHandle = handle;
           
           // Apply code visibility if document has settings
           if (documentVisibilityState) {

--- a/src/components/Notebook.tsx
+++ b/src/components/Notebook.tsx
@@ -1015,7 +1015,8 @@ const Notebook: Component = () => {
               showStderr: codeVisibility.showStderr,
               showResult: codeVisibility.showResult,
               showError: codeVisibility.showError,
-              showStatusDot: codeVisibility.showStatusDot
+              showStatusDot: codeVisibility.showStatusDot,
+              showExecutionCount: codeVisibility.showExecutionCount
             }
           } : loadedDocumentCodeview ? {
             codeview: loadedDocumentCodeview
@@ -1178,7 +1179,8 @@ const Notebook: Component = () => {
            // Validate and extract only known keys
            const validKeys: (keyof CodeVisibilitySettings)[] = [
                "showCode", "showStdout", "showStderr", 
-               "showResult", "showError", "showStatusDot"
+               "showResult", "showError", "showStatusDot",
+               "showExecutionCount"
            ];
            
            const docSettings: Partial<CodeVisibilitySettings> = {};

--- a/src/components/theme-dialog/AdvancedSections.tsx
+++ b/src/components/theme-dialog/AdvancedSections.tsx
@@ -84,6 +84,13 @@ const AdvancedSections: Component = () => {
                     step={100}
                     min={100}
                   />
+                  <NumberUnitInput
+                    label="Letter Spacing"
+                    value={currentTheme.uiTypography.letterSpacing}
+                    onChange={(v) => updateTheme({ uiTypography: { letterSpacing: v } })}
+                    placeholder="app spacing"
+                    step={0.01}
+                  />
                 </div>
             </Section>
 

--- a/src/components/theme-dialog/CoreSections.tsx
+++ b/src/components/theme-dialog/CoreSections.tsx
@@ -127,6 +127,13 @@ const CoreSections: Component = () => {
                 placeholder="0.225rem"
                 step={0.0125}
               />
+              <NumberUnitInput
+                label="Letter Spacing"
+                value={currentTheme.typography.letterSpacing}
+                onChange={(v) => updateTheme({ typography: { ...currentTheme.typography, letterSpacing: v } })}
+                placeholder="normal"
+                step={0.01}
+              />
             </Section>
 
             {/* Code Typography Section */}
@@ -167,6 +174,13 @@ const CoreSections: Component = () => {
                 placeholder="400"
                 step={100}
                 min={100}
+              />
+              <NumberUnitInput
+                label="Letter Spacing"
+                value={currentTheme.codeTypography.letterSpacing}
+                onChange={(v) => updateTheme({ codeTypography: { ...currentTheme.codeTypography, letterSpacing: v } })}
+                placeholder="normal"
+                step={0.01}
               />
             </Section>
 

--- a/src/components/theme-dialog/PreviewPane.tsx
+++ b/src/components/theme-dialog/PreviewPane.tsx
@@ -13,6 +13,7 @@ const PreviewPane: Component = () => {
           {/* Right Panel - Preview */}
           <div class="flex-1 max-lg:h-[24%] shrink-2 min-h-0 p-4 overflow-y-auto space-y-4" style={{
             "font-family": currentTheme.font,
+            "letter-spacing": currentTheme.typography.letterSpacing || "normal",
             "background-color": currentTheme.colors.background,
             "color": currentTheme.colors.secondary,
             "--preview-primary": currentTheme.colors.primary,

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,7 @@ body {
   color: inherit;
   font-family: var(--font-mono);
   font-weight: var(--font-weight-base, normal);
+  letter-spacing: var(--letter-spacing-base, normal);
   line-height: var(--line-spacing);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -157,6 +158,7 @@ select:-webkit-autofill:active {
 @utility ui-font {
   font-family: var(--ui-font-family, var(--font-mono));
   font-weight: var(--ui-font-weight, normal);
+  letter-spacing: var(--ui-letter-spacing, var(--letter-spacing-base, normal));
 }
 
 /* Shared UI divider style + color, applied to chrome dividers/separators
@@ -490,6 +492,7 @@ select:-webkit-autofill:active {
     font-family: var(--code-font-family);
     font-size: var(--code-inline-font-size);
     font-weight: var(--code-font-weight);
+    letter-spacing: var(--code-letter-spacing, normal);
     background-color: color-mix(in srgb, var(--accent) 8%, transparent);
     padding: 0.2em 0.5em;
     border-radius: var(--radius-sm);
@@ -514,6 +517,7 @@ select:-webkit-autofill:active {
     font-family: var(--code-font-family) !important;
     font-size: var(--code-inline-font-size) !important;
     font-weight: var(--code-font-weight) !important;
+    letter-spacing: var(--code-letter-spacing, normal);
     background-color: color-mix(in srgb, var(--accent) 8%, transparent);
     padding: 0.2em 0.5em;
     border-radius: var(--radius-sm);
@@ -551,6 +555,7 @@ select:-webkit-autofill:active {
     font-family: var(--code-font-family) !important;
     font-size: var(--code-base-font-size) !important;
     font-weight: var(--code-font-weight) !important;
+    letter-spacing: var(--code-letter-spacing, normal);
     color: color-mix(in srgb, var(--secondary) 75%, transparent) !important;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,38 @@ import { render } from 'solid-js/web'
 import './index.css'
 import "katex/dist/katex.min.css";
 import App from './App.tsx'
+import { loadThemeFonts, injectCachedThemeFonts } from './lib/font-loader'
+import { loadAppTheme } from './lib/theme'
+import { sessionManager } from './lib/session'
 
 const root = document.getElementById('root')
 
-render(() => <App />, root!)
+// Google fonts referenced by the initial theme (session theme when one
+// exists, else the app theme). Rendering is only ever held up when BOTH are
+// true: a font actually needs a network fetch, and this is a session being
+// created (no restorable session data). Refreshes and reloads of an existing
+// session always render immediately; session-cached font CSS is registered
+// synchronously so the font is still there at first paint, and anything
+// uncached loads in the background and swaps in.
+const boot = (() => {
+  try {
+    const sessionId = sessionManager.getSessionIdFromUrl();
+    const session = sessionId ? sessionManager.loadSession(sessionId) : null;
+    return { theme: session?.theme || loadAppTheme(), existingSession: !!session };
+  } catch {
+    return { theme: null, existingSession: false };
+  }
+})();
+
+const start = () => render(() => <App />, root!)
+if (boot.theme) {
+  const allCached = injectCachedThemeFonts(boot.theme)
+  if (!allCached && !boot.existingSession) {
+    loadThemeFonts(boot.theme).then(start, start)
+  } else {
+    void loadThemeFonts(boot.theme)
+    start()
+  }
+} else {
+  start()
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,38 +3,31 @@ import { render } from 'solid-js/web'
 import './index.css'
 import "katex/dist/katex.min.css";
 import App from './App.tsx'
-import { loadThemeFonts, injectCachedThemeFonts } from './lib/font-loader'
+import { loadThemeFonts } from './lib/font-loader'
 import { loadAppTheme } from './lib/theme'
 import { sessionManager } from './lib/session'
 
 const root = document.getElementById('root')
 
-// Google fonts referenced by the initial theme (session theme when one
-// exists, else the app theme). Rendering is only ever held up when BOTH are
-// true: a font actually needs a network fetch, and this is a session being
-// created (no restorable session data). Refreshes and reloads of an existing
-// session always render immediately; session-cached font CSS is registered
-// synchronously so the font is still there at first paint, and anything
-// uncached loads in the background and swaps in.
-const boot = (() => {
+// Fetch any Google fonts the initial theme references before first render,
+// so the first paint already uses them (no fallback-font flash). The theme
+// applied on mount is the session theme when one exists, else the app theme.
+const initialTheme = (() => {
   try {
     const sessionId = sessionManager.getSessionIdFromUrl();
     const session = sessionId ? sessionManager.loadSession(sessionId) : null;
-    return { theme: session?.theme || loadAppTheme(), existingSession: !!session };
+    return session?.theme || loadAppTheme();
   } catch {
-    return { theme: null, existingSession: false };
+    return null;
   }
 })();
 
 const start = () => render(() => <App />, root!)
-if (boot.theme) {
-  const allCached = injectCachedThemeFonts(boot.theme)
-  if (!allCached && !boot.existingSession) {
-    loadThemeFonts(boot.theme).then(start, start)
-  } else {
-    void loadThemeFonts(boot.theme)
-    start()
-  }
+if (initialTheme) {
+  // Resolves immediately when the theme's fonts are cached or bundled; only
+  // a genuinely un-fetched Google font holds first render, capped at 1.5s so
+  // a slow network can't leave the preloader background up for long.
+  loadThemeFonts(initialTheme, 1500).then(start, start)
 } else {
   start()
 }

--- a/src/lib/codeVisibility.ts
+++ b/src/lib/codeVisibility.ts
@@ -8,6 +8,7 @@ export interface CodeVisibilitySettings {
     showResult: boolean;
     showError: boolean;
     showStatusDot: boolean;
+    showExecutionCount: boolean;
     saveToExport: boolean;
     showLineNumbers: boolean;
     lineWrap: boolean;
@@ -67,6 +68,7 @@ const defaultSettings: CodeVisibilitySettings = {
     showResult: true,
     showError: true,
     showStatusDot: true,
+    showExecutionCount: true,
     saveToExport: false,
     showLineNumbers: false,
     lineWrap: true,
@@ -95,7 +97,8 @@ let userHasOverriddenSettings = false;
 // Track if any setting is hidden (for showing toggle button)
 export const hasHiddenElements = () => {
     return !settings.showCode || !settings.showStdout || !settings.showStderr ||
-        !settings.showResult || !settings.showError || !settings.showStatusDot;
+        !settings.showResult || !settings.showError || !settings.showStatusDot ||
+        !settings.showExecutionCount;
 };
 
 // Per-cell override: when true, show all regardless of settings
@@ -310,6 +313,7 @@ export const getEffectiveVisibility = (
             showResult: cellMetadata.showResult ?? settings.showResult,
             showError: cellMetadata.showError ?? settings.showError,
             showStatusDot: cellMetadata.showStatusDot ?? settings.showStatusDot,
+            showExecutionCount: settings.showExecutionCount, // Notebook-level only
             saveToExport: settings.saveToExport, // This is app-level only
             showLineNumbers: settings.showLineNumbers, // This is app-level only
             lineWrap: settings.lineWrap, // This is app-level only

--- a/src/lib/file-handles.ts
+++ b/src/lib/file-handles.ts
@@ -1,0 +1,56 @@
+// Persist FileSystemFileHandle objects across page reloads. Sessions live in
+// localStorage, which can't hold handles, but IndexedDB can (they survive the
+// structured clone), so handles are stored here keyed by session id. On
+// restore the handle may need permission re-granted; the save path handles
+// that since permission prompts require a user gesture.
+
+const DB_NAME = "pynote-file-handles";
+const STORE = "handles";
+
+const openDb = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+const withStore = async <T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> => {
+  const db = await openDb();
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const req = fn(db.transaction(STORE, mode).objectStore(STORE));
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  } finally {
+    db.close();
+  }
+};
+
+export const saveFileHandle = async (sessionId: string, handle: FileSystemFileHandle) => {
+  try {
+    await withStore("readwrite", (s) => s.put(handle, sessionId));
+  } catch {
+    // Persistence is best-effort; saving still works via picker/download.
+  }
+};
+
+export const loadFileHandle = async (sessionId: string): Promise<FileSystemFileHandle | null> => {
+  try {
+    return ((await withStore("readonly", (s) => s.get(sessionId))) as FileSystemFileHandle) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export const deleteFileHandle = async (sessionId: string) => {
+  try {
+    await withStore("readwrite", (s) => s.delete(sessionId));
+  } catch {
+    // Stale entries are harmless.
+  }
+};

--- a/src/lib/font-loader.ts
+++ b/src/lib/font-loader.ts
@@ -1,0 +1,173 @@
+// Runtime Google Fonts loader for theme font families.
+//
+// The theme dialog's font inputs accept any CSS font-family string. The
+// dropdown fonts ship with the build (fontsource imports in index.css); any
+// other family is fetched from Google Fonts at runtime so themed notebooks
+// render the same on machines that don't have the font installed. Callers
+// that apply a whole theme at once (file open, session restore) await
+// loadThemeFonts() before applying it, so the font lands in the same paint
+// as the rest of the styling instead of swapping in late.
+
+import { FONT_OPTIONS } from "../components/theme-dialog/constants";
+
+// First family in a font-family stack, unquoted. Null for empty stacks.
+export function primaryFamily(stack: string): string | null {
+  const first = (stack || "").split(",")[0].trim().replace(/^["']|["']$/g, "").trim();
+  return first || null;
+}
+
+const GENERIC_FAMILIES = new Set([
+  "monospace", "sans-serif", "serif", "system-ui", "cursive", "fantasy",
+  "math", "emoji", "fangsong", "ui-monospace", "ui-sans-serif", "ui-serif",
+  "ui-rounded", "inherit", "initial", "unset", "revert",
+]);
+
+// Families bundled with the app. Derived from the theme dialog's dropdown
+// options so the two stay in sync.
+const BUNDLED_FAMILIES = new Set(
+  FONT_OPTIONS.map((o) => primaryFamily(o.value)).filter(Boolean) as string[]
+);
+
+// One attempt per family per page load. Failures are cached too, since the
+// request 400s for families Google doesn't have (system fonts, typos) and
+// retrying won't change that.
+const attempted = new Map<string, Promise<void>>();
+
+interface ThemeFontFields {
+  font?: string;
+  codeTypography?: { fontFamily?: string };
+  uiTypography?: { fontFamily?: string };
+}
+
+// Non-bundled, non-generic families a theme references.
+const collectFamilies = (theme: ThemeFontFields): Set<string> => {
+  const families = new Set<string>();
+  for (const stack of [theme.font, theme.codeTypography?.fontFamily, theme.uiTypography?.fontFamily]) {
+    const family = primaryFamily(stack || "");
+    if (!family || GENERIC_FAMILIES.has(family.toLowerCase()) || BUNDLED_FAMILIES.has(family)) continue;
+    families.add(family);
+  }
+  return families;
+};
+
+// Session-scoped cache of fetched @font-face CSS, so reloads in the same tab
+// (refresh, the no-handle file-open path) skip the network round-trip
+// entirely. A "!" entry means Google definitively doesn't have the family
+// (HTTP error, not a network failure), so don't ask again this session.
+const CACHE_PREFIX = "pynote-gfont-";
+const NOT_AVAILABLE = "!";
+const readCssCache = (family: string): string | null => {
+  try { return sessionStorage.getItem(CACHE_PREFIX + family); } catch { return null; }
+};
+const writeCssCache = (family: string, css: string) => {
+  try { sessionStorage.setItem(CACHE_PREFIX + family, css); } catch { /* quota; skip */ }
+};
+
+const injectAndLoad = async (family: string, css: string): Promise<void> => {
+  const style = document.createElement("style");
+  style.setAttribute("data-google-font", family);
+  style.textContent = css;
+  document.head.appendChild(style);
+  // Registering the font faces doesn't download anything by itself, so
+  // kick the fetches now and resolve once the family is usable. The font
+  // binaries themselves come from the browser HTTP cache on repeat loads
+  // (gstatic serves them with year-long max-age).
+  await Promise.allSettled([
+    document.fonts.load(`400 1em "${family}"`),
+    document.fonts.load(`700 1em "${family}"`),
+    document.fonts.load(`italic 400 1em "${family}"`),
+  ]);
+};
+
+// Boot fast path. When every family the theme needs is already in the session
+// cache, inject the CSS synchronously (so the faces are registered before
+// first paint) and let the binaries activate from the browser cache in
+// parallel instead of holding up render. font-display: block covers the frame
+// or two of disk-cache activation with invisible text rather than a visible
+// fallback-font swap. Returns false when some family needs a network fetch,
+// in which case the caller should use loadThemeFonts and wait.
+export const injectCachedThemeFonts = (theme: ThemeFontFields): boolean => {
+  if (typeof document === "undefined" || !document.fonts) return true;
+  for (const family of collectFamilies(theme)) {
+    if (attempted.has(family)) continue;
+    const cached = readCssCache(family);
+    if (cached === null) return false;
+    if (cached === NOT_AVAILABLE) {
+      attempted.set(family, Promise.resolve());
+      continue;
+    }
+    // Registration only, no explicit document.fonts.load: the first layout
+    // that uses the family kicks off the (browser-cached) fetch by itself,
+    // and font-display: block hides activation. Keeps pre-render work minimal.
+    const style = document.createElement("style");
+    style.setAttribute("data-google-font", family);
+    style.textContent = cached.replace(/font-display:\s*swap/g, "font-display: block");
+    document.head.appendChild(style);
+    attempted.set(family, Promise.resolve());
+  }
+  return true;
+};
+
+const fetchAndRegister = async (family: string): Promise<void> => {
+  const cached = readCssCache(family);
+  if (cached === NOT_AVAILABLE) return;
+  if (cached) return injectAndLoad(family, cached);
+
+  const name = encodeURIComponent(family).replace(/%20/g, "+");
+  // Variable fonts first (full weight range), then common static weights,
+  // then regular only. Google rejects axis ranges a family doesn't support.
+  const candidates = [
+    `family=${name}:ital,wght@0,100..900;1,100..900`,
+    `family=${name}:ital,wght@0,400;0,500;0,600;0,700;1,400;1,700`,
+    `family=${name}`,
+  ];
+  let sawResponse = false;
+  for (const query of candidates) {
+    try {
+      const res = await fetch(`https://fonts.googleapis.com/css2?${query}&display=swap`);
+      sawResponse = true;
+      if (!res.ok) continue;
+      const css = await res.text();
+      writeCssCache(family, css);
+      return injectAndLoad(family, css);
+    } catch {
+      // Network error. Try the next candidate, then give up silently and let
+      // the font stack's fallback keep rendering as before.
+    }
+  }
+  // Every candidate got an HTTP error: the family isn't on Google Fonts.
+  // Network errors don't count; those should retry on the next page load.
+  if (sawResponse) writeCssCache(family, NOT_AVAILABLE);
+};
+
+const loadFamily = (family: string): Promise<void> => {
+  let pending = attempted.get(family);
+  if (!pending) {
+    pending = fetchAndRegister(family);
+    attempted.set(family, pending);
+  }
+  return pending;
+};
+
+// Load every non-bundled font family a theme references. Resolves when the
+// fonts are ready, or after timeoutMs so a dead network can't hold the theme
+// hostage (a late font still swaps in via font-display: swap).
+export const loadThemeFonts = (theme: ThemeFontFields, timeoutMs = 2500): Promise<void> => {
+  if (typeof document === "undefined" || !document.fonts) return Promise.resolve();
+  const families = collectFamilies(theme);
+  if (families.size === 0) return Promise.resolve();
+  const all = Promise.all([...families].map(loadFamily)).then(() => undefined);
+  // Offline: kick the attempts off (they fail fast and get retried on the
+  // next page load) but don't make callers wait on a network we don't have.
+  if (typeof navigator !== "undefined" && navigator.onLine === false) return Promise.resolve();
+  const cap = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
+  return Promise.race([all, cap]);
+};
+
+// Debounced catch-all for live theme edits. The dialog's font inputs fire on
+// every keystroke, so wait for the name to settle before hitting Google.
+let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+export const scheduleThemeFontLoad = (theme: ThemeFontFields) => {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => void loadThemeFonts(theme), 600);
+};

--- a/src/lib/font-loader.ts
+++ b/src/lib/font-loader.ts
@@ -79,40 +79,7 @@ const injectAndLoad = async (family: string, css: string): Promise<void> => {
   ]);
 };
 
-// Boot fast path. When every family the theme needs is already in the session
-// cache, inject the CSS synchronously (so the faces are registered before
-// first paint) and let the binaries activate from the browser cache in
-// parallel instead of holding up render. font-display: block covers the frame
-// or two of disk-cache activation with invisible text rather than a visible
-// fallback-font swap. Returns false when some family needs a network fetch,
-// in which case the caller should use loadThemeFonts and wait.
-export const injectCachedThemeFonts = (theme: ThemeFontFields): boolean => {
-  if (typeof document === "undefined" || !document.fonts) return true;
-  for (const family of collectFamilies(theme)) {
-    if (attempted.has(family)) continue;
-    const cached = readCssCache(family);
-    if (cached === null) return false;
-    if (cached === NOT_AVAILABLE) {
-      attempted.set(family, Promise.resolve());
-      continue;
-    }
-    // Registration only, no explicit document.fonts.load: the first layout
-    // that uses the family kicks off the (browser-cached) fetch by itself,
-    // and font-display: block hides activation. Keeps pre-render work minimal.
-    const style = document.createElement("style");
-    style.setAttribute("data-google-font", family);
-    style.textContent = cached.replace(/font-display:\s*swap/g, "font-display: block");
-    document.head.appendChild(style);
-    attempted.set(family, Promise.resolve());
-  }
-  return true;
-};
-
 const fetchAndRegister = async (family: string): Promise<void> => {
-  const cached = readCssCache(family);
-  if (cached === NOT_AVAILABLE) return;
-  if (cached) return injectAndLoad(family, cached);
-
   const name = encodeURIComponent(family).replace(/%20/g, "+");
   // Variable fonts first (full weight range), then common static weights,
   // then regular only. Google rejects axis ranges a family doesn't support.
@@ -149,14 +116,34 @@ const loadFamily = (family: string): Promise<void> => {
   return pending;
 };
 
-// Load every non-bundled font family a theme references. Resolves when the
-// fonts are ready, or after timeoutMs so a dead network can't hold the theme
-// hostage (a late font still swaps in via font-display: swap).
+// Load every non-bundled font family a theme references. Cached families
+// (session cache from an earlier load) inject synchronously and activate from
+// the browser cache in parallel, costing callers nothing. Only families that
+// need a network fetch are waited on, capped at timeoutMs so a dead network
+// can't hold the theme hostage (a late font still swaps in when it arrives).
 export const loadThemeFonts = (theme: ThemeFontFields, timeoutMs = 2500): Promise<void> => {
   if (typeof document === "undefined" || !document.fonts) return Promise.resolve();
-  const families = collectFamilies(theme);
-  if (families.size === 0) return Promise.resolve();
-  const all = Promise.all([...families].map(loadFamily)).then(() => undefined);
+  const needsFetch: string[] = [];
+  for (const family of collectFamilies(theme)) {
+    if (attempted.has(family)) continue;
+    const cached = readCssCache(family);
+    if (cached === NOT_AVAILABLE) {
+      // Known not to be on Google Fonts (system font, typo). Nothing to do.
+      attempted.set(family, Promise.resolve());
+    } else if (cached !== null) {
+      // Cached CSS: register the faces now, activate in parallel. The
+      // font-display: block rewrite covers the frame or two of disk-cache
+      // activation with invisible text instead of a visible font swap.
+      attempted.set(
+        family,
+        injectAndLoad(family, cached.replace(/font-display:\s*swap/g, "font-display: block"))
+      );
+    } else {
+      needsFetch.push(family);
+    }
+  }
+  if (needsFetch.length === 0) return Promise.resolve();
+  const all = Promise.all(needsFetch.map(loadFamily)).then(() => undefined);
   // Offline: kick the attempts off (they fail fast and get retried on the
   // next page load) but don't make callers wait on a network we don't have.
   if (typeof navigator !== "undefined" && navigator.onLine === false) return Promise.resolve();

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,3 +1,5 @@
+import { deleteFileHandle } from "./file-handles";
+
 export interface SessionMeta {
     id: string;
     filename: string;
@@ -63,6 +65,7 @@ export const sessionManager = {
             if (toRemove) {
                 evictedId = toRemove.id;
                 localStorage.removeItem(`${SESSION_PREFIX}${toRemove.id}`);
+                void deleteFileHandle(toRemove.id);
             }
         }
 
@@ -106,11 +109,15 @@ export const sessionManager = {
         localStorage.removeItem(`${SESSION_PREFIX}${id}`);
         const sessions = this.getSessions().filter(s => s.id !== id);
         localStorage.setItem(INDEX_KEY, JSON.stringify(sessions));
+        void deleteFileHandle(id);
     },
 
     clearAllSessions() {
         const sessions = this.getSessions();
-        sessions.forEach(s => localStorage.removeItem(`${SESSION_PREFIX}${s.id}`));
+        sessions.forEach(s => {
+            localStorage.removeItem(`${SESSION_PREFIX}${s.id}`);
+            void deleteFileHandle(s.id);
+        });
         localStorage.removeItem(INDEX_KEY);
     }
 };

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -49,6 +49,7 @@ export interface Theme {
     headerDelta: string;
     headerColors?: string[];
     headerMarginBottom: string;
+    letterSpacing: string;
   };
   codeTypography: {
     fontFamily: string;
@@ -56,6 +57,7 @@ export interface Theme {
     baseFontSize: string;
     inlineFontSize: string;
     editorFontSize: string;
+    letterSpacing: string;
   };
   editor: {
     maxCodeHeight: string;
@@ -67,6 +69,7 @@ export interface Theme {
     fontFamily: string;
     fontWeight: string;
     menuFontWeight: string;
+    letterSpacing: string;
   };
   // Shared border for UI element frames (dialogs, dropdowns, menus, toggles, inputs).
   // Empty string = inherit current behavior (1px solid, foreground color).
@@ -394,6 +397,7 @@ export const defaultTheme: Theme = {
     headerDelta: "0.225rem",
     headerColors: ["#f38ba8", "#fab387", "#f9e2af", "#a6e3a1"],
     headerMarginBottom: "1.75rem",
+    letterSpacing: "",
   },
   codeTypography: {
     fontFamily: '"JetBrains Mono Variable", monospace',
@@ -401,6 +405,7 @@ export const defaultTheme: Theme = {
     baseFontSize: "0.875rem",
     inlineFontSize: "0.875rem",
     editorFontSize: "1rem",
+    letterSpacing: "",
   },
   editor: {
     maxCodeHeight: "none",
@@ -409,6 +414,7 @@ export const defaultTheme: Theme = {
     fontFamily: "",
     fontWeight: "",
     menuFontWeight: "",
+    letterSpacing: "",
   },
   uiBorder: {
     color: "",
@@ -619,12 +625,14 @@ export const initTheme = () => {
     root.style.setProperty("--font-size-base", theme.typography.fontSize);
     root.style.setProperty("--font-size-delta", theme.typography.headerDelta);
     root.style.setProperty("--header-margin-bottom", theme.typography.headerMarginBottom);
+    root.style.setProperty("--letter-spacing-base", theme.typography.letterSpacing || "normal");
 
     root.style.setProperty("--code-font-family", theme.codeTypography.fontFamily);
     root.style.setProperty("--code-font-weight", theme.codeTypography.fontWeight);
     root.style.setProperty("--code-base-font-size", theme.codeTypography.baseFontSize);
     root.style.setProperty("--code-inline-font-size", theme.codeTypography.inlineFontSize);
     root.style.setProperty("--code-editor-font-size", theme.codeTypography.editorFontSize);
+    root.style.setProperty("--code-letter-spacing", theme.codeTypography.letterSpacing || "normal");
 
     root.style.setProperty("--editor-max-code-height", theme.editor.maxCodeHeight);
 
@@ -633,6 +641,7 @@ export const initTheme = () => {
     root.style.setProperty("--ui-font-family", theme.uiTypography.fontFamily || "var(--font-mono)");
     root.style.setProperty("--ui-font-weight", theme.uiTypography.fontWeight || "var(--font-weight-base)");
     root.style.setProperty("--menu-font-weight", theme.uiTypography.menuFontWeight || "600");
+    root.style.setProperty("--ui-letter-spacing", theme.uiTypography.letterSpacing || "var(--letter-spacing-base)");
 
     // Shared UI element border (frames + dividers). Each of `border`/`divider`
     // may carry its own width, style and color; anything omitted falls back to

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,6 +1,7 @@
 import { createStore } from "solid-js/store";
 import { createEffect } from "solid-js";
 import { resolveBorder } from "../components/ui-renderer/colorUtils";
+import { scheduleThemeFontLoad } from "./font-loader";
 
 export interface Theme {
   font: string;
@@ -577,6 +578,12 @@ export const initTheme = () => {
     const body = document.body;
     root.style.setProperty("--font-mono", theme.font);
     root.style.setProperty("--font-weight-base", theme.fontWeight || "normal");
+
+    // Catch-all for live edits (theme dialog font inputs): fetch any Google
+    // font the theme now references. Debounced since inputs fire per
+    // keystroke; the font swaps in when ready. Whole-theme loads (file open,
+    // session restore, boot) await loadThemeFonts before applying instead.
+    scheduleThemeFontLoad(theme);
 
     // Set base theme variables (--primary, --secondary, etc.)
     // The @theme inline block in index.css will map these to --color-* for Tailwind utilities


### PR DESCRIPTION
Lets themed notebooks use any Google font without it being bundled, adds letter spacing controls to the typography sections, adds an execution count visibility toggle, and fixes a set of file saving and code visibility save issues.

### What's in here

**Google Fonts loading**

- New font-loader.ts: any font family a theme references that isn't bundled (and isn't a generic like `monospace`) gets fetched from Google Fonts at runtime, so themed notebooks render the same on machines that don't have the font installed
- Whole-theme loads wait for the fonts (bounded), so the font lands in the same paint as the rest of the theme instead of swapping in late. First render waits up to 1.5s, opening a file waits up to 250ms, and past the cap the font swaps in when it arrives
- Fetched `@font-face` CSS is cached in sessionStorage, with a marker for families Google doesn't have (system fonts, typos) so those don't get re-requested. The font binaries themselves come from the browser HTTP cache on repeat loads
- Live edits in the theme dialog's font inputs are debounced, so the fetch fires once the name settles instead of on every keystroke
- Preconnect hints for the Google Fonts hosts in index.html

**Letter spacing**
- New Letter Spacing inputs in the Typography, Code Typography, and UI Typography sections
- Backed by new theme variables applied to the body, the editor, inline and block code, and the `ui-font` utility. UI spacing falls back to the base spacing when left empty
- The theme preview pane reflects the base letter spacing

**Execution count toggle**
- New Execution Count checkbox in the code visibility dialog (notebook scope only) that hides the `[n]:` gutter on code cells
- Persists with the rest of the visibility settings (session and document metadata) and counts toward the hidden-elements indicator

**File saving fixes**
- File handles now survive page reloads: new file-handles.ts stores them in IndexedDB keyed by session id (localStorage can't hold handles), so Save keeps targeting the opened file after a refresh instead of falling back to the picker
- Save re-requests write permission when the browser dropped it after a reload (Save is a user gesture, so prompting is allowed)
- Stored handles are cleaned up when sessions are deleted, cleared, or evicted

**Code visibility save fixes**
- Saving the dialog no longer undos the above/below output layout choice 
- With save-to-export on, the current output layout now wins over the stale value written back from the loaded document theme, and documents without a theme get just the layout toggle persisted

Also in here: a unit test for the new letter spacing theme variables, and a few throwaway verify scripts under scripts.